### PR TITLE
Use new runic version to generate cleaner bindings

### DIFF
--- a/prepocess/rune.yml
+++ b/prepocess/rune.yml
@@ -4,18 +4,45 @@ platforms:
 from:
   language: c
   static: "libuv.a"
+  shared: "libuv.so"
   headers: 
-     - "/usr/include/uv.h"
+     - "src/uv.h"
   includedirs:
-    - "/usr/include/uv"
+    - "src"
+  defines:
+    UV_EXTERN: "extern"
+    ssize_t: "signed long"
+  extern:
+    - "src/stdio.h"
+    - "src/sys/*"
+    - "src/pthread.h"
+    - "src/dirent.h"
+    - "src/fcntl.h"
+  overwrite:
+    types:
+      "uv_sem_t": "#UInt8 #Attr Arr 32 #AttrEnd"
+  ignore:
+    types:
+      - "sem_t"
+      - "uv_once_t"
 to:
   language: odin
   package: uv
   trim_prefix:
-    functions: uv_
-    types: Uv_
-    constants: UV_
+    - uv__
+    - uv_
+    - UV_
   no_build_tag: yes
-  use_when_else: yes
-  ignore_arch: yes
   out: "uv-normal/uv.odin"
+  extern:
+    sources:
+      "src/stdio.h": "core:c/libc"
+      "src/sys/types.h": "core:sys/linux"
+      "src/sys/socket.h": "core:sys/posix"
+      "src/pthread.h": "core:sys/posix"
+      "src/dirent.h": "core:sys/posix"
+    remaps:
+      "pid_t": "Pid"
+      "gid_t": "Gid"
+      "uid_t": "Uid"
+

--- a/prepocess/src/dirent.h
+++ b/prepocess/src/dirent.h
@@ -1,0 +1,3 @@
+typedef int DIR;
+typedef int mode_t;
+typedef int off_t;

--- a/prepocess/src/fcntl.h
+++ b/prepocess/src/fcntl.h
@@ -1,0 +1,1 @@
+typedef char pthread_rwlock_t[56];

--- a/prepocess/src/pthread.h
+++ b/prepocess/src/pthread.h
@@ -1,0 +1,6 @@
+typedef int pthread_once_t;
+typedef int pthread_t;
+typedef char pthread_mutex_t[48];
+typedef int pthread_cond_t;
+typedef int pthread_key_t;
+

--- a/prepocess/src/stdio.h
+++ b/prepocess/src/stdio.h
@@ -1,0 +1,1 @@
+typedef int FILE;

--- a/prepocess/src/sys/socket.h
+++ b/prepocess/src/sys/socket.h
@@ -1,0 +1,6 @@
+struct addrinfo {};
+struct sockaddr {};
+struct sockaddr_storage {};
+struct sockaddr_in {};
+struct sockaddr_in6 {};
+struct termios {};

--- a/prepocess/src/sys/types.h
+++ b/prepocess/src/sys/types.h
@@ -1,0 +1,5 @@
+typedef int pid_t;
+typedef int gid_t;
+typedef int uid_t;
+
+typedef int sem_t;

--- a/prepocess/src/uv.h
+++ b/prepocess/src/uv.h
@@ -1,0 +1,1970 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* See https://github.com/libuv/libuv#documentation for documentation. */
+
+#ifndef UV_H
+#define UV_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(BUILDING_UV_SHARED) && defined(USING_UV_SHARED)
+#error "Define either BUILDING_UV_SHARED or USING_UV_SHARED, not both."
+#endif
+
+#ifndef UV_EXTERN
+#ifdef _WIN32
+  /* Windows - set up dll import/export decorators. */
+# if defined(BUILDING_UV_SHARED)
+    /* Building shared library. */
+#   define UV_EXTERN __declspec(dllexport)
+# elif defined(USING_UV_SHARED)
+    /* Using shared library. */
+#   define UV_EXTERN __declspec(dllimport)
+# else
+    /* Building static library. */
+#   define UV_EXTERN /* nothing */
+# endif
+#elif __GNUC__ >= 4
+# define UV_EXTERN __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550) /* Sun Studio >= 8 */
+# define UV_EXTERN __global
+#else
+# define UV_EXTERN /* nothing */
+#endif
+#endif /* UV_EXTERN */
+
+#include "uv/errno.h"
+#include "uv/version.h"
+#include <stddef.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* Internal type, do not use. */
+struct uv__queue {
+  struct uv__queue* next;
+  struct uv__queue* prev;
+};
+
+#if defined(_WIN32)
+# include "uv/win.h"
+#else
+# include "uv/unix.h"
+#endif
+
+/* Expand this list if necessary. */
+#define UV_ERRNO_MAP(XX)                                                      \
+  XX(E2BIG, "argument list too long")                                         \
+  XX(EACCES, "permission denied")                                             \
+  XX(EADDRINUSE, "address already in use")                                    \
+  XX(EADDRNOTAVAIL, "address not available")                                  \
+  XX(EAFNOSUPPORT, "address family not supported")                            \
+  XX(EAGAIN, "resource temporarily unavailable")                              \
+  XX(EAI_ADDRFAMILY, "address family not supported")                          \
+  XX(EAI_AGAIN, "temporary failure")                                          \
+  XX(EAI_BADFLAGS, "bad ai_flags value")                                      \
+  XX(EAI_BADHINTS, "invalid value for hints")                                 \
+  XX(EAI_CANCELED, "request canceled")                                        \
+  XX(EAI_FAIL, "permanent failure")                                           \
+  XX(EAI_FAMILY, "ai_family not supported")                                   \
+  XX(EAI_MEMORY, "out of memory")                                             \
+  XX(EAI_NODATA, "no address")                                                \
+  XX(EAI_NONAME, "unknown node or service")                                   \
+  XX(EAI_OVERFLOW, "argument buffer overflow")                                \
+  XX(EAI_PROTOCOL, "resolved protocol is unknown")                            \
+  XX(EAI_SERVICE, "service not available for socket type")                    \
+  XX(EAI_SOCKTYPE, "socket type not supported")                               \
+  XX(EALREADY, "connection already in progress")                              \
+  XX(EBADF, "bad file descriptor")                                            \
+  XX(EBUSY, "resource busy or locked")                                        \
+  XX(ECANCELED, "operation canceled")                                         \
+  XX(ECHARSET, "invalid Unicode character")                                   \
+  XX(ECONNABORTED, "software caused connection abort")                        \
+  XX(ECONNREFUSED, "connection refused")                                      \
+  XX(ECONNRESET, "connection reset by peer")                                  \
+  XX(EDESTADDRREQ, "destination address required")                            \
+  XX(EEXIST, "file already exists")                                           \
+  XX(EFAULT, "bad address in system call argument")                           \
+  XX(EFBIG, "file too large")                                                 \
+  XX(EHOSTUNREACH, "host is unreachable")                                     \
+  XX(EINTR, "interrupted system call")                                        \
+  XX(EINVAL, "invalid argument")                                              \
+  XX(EIO, "i/o error")                                                        \
+  XX(EISCONN, "socket is already connected")                                  \
+  XX(EISDIR, "illegal operation on a directory")                              \
+  XX(ELOOP, "too many symbolic links encountered")                            \
+  XX(EMFILE, "too many open files")                                           \
+  XX(EMSGSIZE, "message too long")                                            \
+  XX(ENAMETOOLONG, "name too long")                                           \
+  XX(ENETDOWN, "network is down")                                             \
+  XX(ENETUNREACH, "network is unreachable")                                   \
+  XX(ENFILE, "file table overflow")                                           \
+  XX(ENOBUFS, "no buffer space available")                                    \
+  XX(ENODEV, "no such device")                                                \
+  XX(ENOENT, "no such file or directory")                                     \
+  XX(ENOMEM, "not enough memory")                                             \
+  XX(ENONET, "machine is not on the network")                                 \
+  XX(ENOPROTOOPT, "protocol not available")                                   \
+  XX(ENOSPC, "no space left on device")                                       \
+  XX(ENOSYS, "function not implemented")                                      \
+  XX(ENOTCONN, "socket is not connected")                                     \
+  XX(ENOTDIR, "not a directory")                                              \
+  XX(ENOTEMPTY, "directory not empty")                                        \
+  XX(ENOTSOCK, "socket operation on non-socket")                              \
+  XX(ENOTSUP, "operation not supported on socket")                            \
+  XX(EOVERFLOW, "value too large for defined data type")                      \
+  XX(EPERM, "operation not permitted")                                        \
+  XX(EPIPE, "broken pipe")                                                    \
+  XX(EPROTO, "protocol error")                                                \
+  XX(EPROTONOSUPPORT, "protocol not supported")                               \
+  XX(EPROTOTYPE, "protocol wrong type for socket")                            \
+  XX(ERANGE, "result too large")                                              \
+  XX(EROFS, "read-only file system")                                          \
+  XX(ESHUTDOWN, "cannot send after transport endpoint shutdown")              \
+  XX(ESPIPE, "invalid seek")                                                  \
+  XX(ESRCH, "no such process")                                                \
+  XX(ETIMEDOUT, "connection timed out")                                       \
+  XX(ETXTBSY, "text file is busy")                                            \
+  XX(EXDEV, "cross-device link not permitted")                                \
+  XX(UNKNOWN, "unknown error")                                                \
+  XX(EOF, "end of file")                                                      \
+  XX(ENXIO, "no such device or address")                                      \
+  XX(EMLINK, "too many links")                                                \
+  XX(EHOSTDOWN, "host is down")                                               \
+  XX(EREMOTEIO, "remote I/O error")                                           \
+  XX(ENOTTY, "inappropriate ioctl for device")                                \
+  XX(EFTYPE, "inappropriate file type or format")                             \
+  XX(EILSEQ, "illegal byte sequence")                                         \
+  XX(ESOCKTNOSUPPORT, "socket type not supported")                            \
+  XX(ENODATA, "no data available")                                            \
+  XX(EUNATCH, "protocol driver not attached")                                 \
+
+#define UV_HANDLE_TYPE_MAP(XX)                                                \
+  XX(ASYNC, async)                                                            \
+  XX(CHECK, check)                                                            \
+  XX(FS_EVENT, fs_event)                                                      \
+  XX(FS_POLL, fs_poll)                                                        \
+  XX(HANDLE, handle)                                                          \
+  XX(IDLE, idle)                                                              \
+  XX(NAMED_PIPE, pipe)                                                        \
+  XX(POLL, poll)                                                              \
+  XX(PREPARE, prepare)                                                        \
+  XX(PROCESS, process)                                                        \
+  XX(STREAM, stream)                                                          \
+  XX(TCP, tcp)                                                                \
+  XX(TIMER, timer)                                                            \
+  XX(TTY, tty)                                                                \
+  XX(UDP, udp)                                                                \
+  XX(SIGNAL, signal)                                                          \
+
+#define UV_REQ_TYPE_MAP(XX)                                                   \
+  XX(REQ, req)                                                                \
+  XX(CONNECT, connect)                                                        \
+  XX(WRITE, write)                                                            \
+  XX(SHUTDOWN, shutdown)                                                      \
+  XX(UDP_SEND, udp_send)                                                      \
+  XX(FS, fs)                                                                  \
+  XX(WORK, work)                                                              \
+  XX(GETADDRINFO, getaddrinfo)                                                \
+  XX(GETNAMEINFO, getnameinfo)                                                \
+  XX(RANDOM, random)                                                          \
+
+typedef enum {
+#define XX(code, _) UV_ ## code = UV__ ## code,
+  UV_ERRNO_MAP(XX)
+#undef XX
+  UV_ERRNO_MAX = UV__EOF - 1
+} uv_errno_t;
+
+typedef enum {
+  UV_UNKNOWN_HANDLE = 0,
+#define XX(uc, lc) UV_##uc,
+  UV_HANDLE_TYPE_MAP(XX)
+#undef XX
+  UV_FILE,
+  UV_HANDLE_TYPE_MAX
+} uv_handle_type;
+
+typedef enum {
+  UV_UNKNOWN_REQ = 0,
+#define XX(uc, lc) UV_##uc,
+  UV_REQ_TYPE_MAP(XX)
+#undef XX
+  UV_REQ_TYPE_PRIVATE
+  UV_REQ_TYPE_MAX
+} uv_req_type;
+
+
+/* Handle types. */
+typedef struct uv_loop_s uv_loop_t;
+typedef struct uv_handle_s uv_handle_t;
+typedef struct uv_dir_s uv_dir_t;
+typedef struct uv_stream_s uv_stream_t;
+typedef struct uv_tcp_s uv_tcp_t;
+typedef struct uv_udp_s uv_udp_t;
+typedef struct uv_pipe_s uv_pipe_t;
+typedef struct uv_tty_s uv_tty_t;
+typedef struct uv_poll_s uv_poll_t;
+typedef struct uv_timer_s uv_timer_t;
+typedef struct uv_prepare_s uv_prepare_t;
+typedef struct uv_check_s uv_check_t;
+typedef struct uv_idle_s uv_idle_t;
+typedef struct uv_async_s uv_async_t;
+typedef struct uv_process_s uv_process_t;
+typedef struct uv_fs_event_s uv_fs_event_t;
+typedef struct uv_fs_poll_s uv_fs_poll_t;
+typedef struct uv_signal_s uv_signal_t;
+
+/* Request types. */
+typedef struct uv_req_s uv_req_t;
+typedef struct uv_getaddrinfo_s uv_getaddrinfo_t;
+typedef struct uv_getnameinfo_s uv_getnameinfo_t;
+typedef struct uv_shutdown_s uv_shutdown_t;
+typedef struct uv_write_s uv_write_t;
+typedef struct uv_connect_s uv_connect_t;
+typedef struct uv_udp_send_s uv_udp_send_t;
+typedef struct uv_fs_s uv_fs_t;
+typedef struct uv_work_s uv_work_t;
+typedef struct uv_random_s uv_random_t;
+
+/* None of the above. */
+typedef struct uv_env_item_s uv_env_item_t;
+typedef struct uv_cpu_info_s uv_cpu_info_t;
+typedef struct uv_interface_address_s uv_interface_address_t;
+typedef struct uv_dirent_s uv_dirent_t;
+typedef struct uv_passwd_s uv_passwd_t;
+typedef struct uv_group_s uv_group_t;
+typedef struct uv_utsname_s uv_utsname_t;
+typedef struct uv_statfs_s uv_statfs_t;
+
+typedef struct uv_metrics_s uv_metrics_t;
+
+typedef enum {
+  UV_LOOP_BLOCK_SIGNAL = 0,
+  UV_METRICS_IDLE_TIME,
+  UV_LOOP_USE_IO_URING_SQPOLL
+#define UV_LOOP_USE_IO_URING_SQPOLL UV_LOOP_USE_IO_URING_SQPOLL
+} uv_loop_option;
+
+typedef enum {
+  UV_RUN_DEFAULT = 0,
+  UV_RUN_ONCE,
+  UV_RUN_NOWAIT
+} uv_run_mode;
+
+
+UV_EXTERN unsigned int uv_version(void);
+UV_EXTERN const char* uv_version_string(void);
+
+typedef void* (*uv_malloc_func)(size_t size);
+typedef void* (*uv_realloc_func)(void* ptr, size_t size);
+typedef void* (*uv_calloc_func)(size_t count, size_t size);
+typedef void (*uv_free_func)(void* ptr);
+
+UV_EXTERN void uv_library_shutdown(void);
+
+UV_EXTERN int uv_replace_allocator(uv_malloc_func malloc_func,
+                                   uv_realloc_func realloc_func,
+                                   uv_calloc_func calloc_func,
+                                   uv_free_func free_func);
+
+UV_EXTERN uv_loop_t* uv_default_loop(void);
+UV_EXTERN int uv_loop_init(uv_loop_t* loop);
+UV_EXTERN int uv_loop_close(uv_loop_t* loop);
+/*
+ * NOTE:
+ *  This function is DEPRECATED, users should
+ *  allocate the loop manually and use uv_loop_init instead.
+ */
+UV_EXTERN uv_loop_t* uv_loop_new(void);
+/*
+ * NOTE:
+ *  This function is DEPRECATED. Users should use
+ *  uv_loop_close and free the memory manually instead.
+ */
+UV_EXTERN void uv_loop_delete(uv_loop_t*);
+UV_EXTERN size_t uv_loop_size(void);
+UV_EXTERN int uv_loop_alive(const uv_loop_t* loop);
+UV_EXTERN int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...);
+UV_EXTERN int uv_loop_fork(uv_loop_t* loop);
+
+UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
+UV_EXTERN void uv_stop(uv_loop_t*);
+
+UV_EXTERN void uv_ref(uv_handle_t*);
+UV_EXTERN void uv_unref(uv_handle_t*);
+UV_EXTERN int uv_has_ref(const uv_handle_t*);
+
+UV_EXTERN void uv_update_time(uv_loop_t*);
+UV_EXTERN uint64_t uv_now(const uv_loop_t*);
+
+UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
+
+typedef void (*uv_alloc_cb)(uv_handle_t* handle,
+                            size_t suggested_size,
+                            uv_buf_t* buf);
+typedef void (*uv_read_cb)(uv_stream_t* stream,
+                           ssize_t nread,
+                           const uv_buf_t* buf);
+typedef void (*uv_write_cb)(uv_write_t* req, int status);
+typedef void (*uv_connect_cb)(uv_connect_t* req, int status);
+typedef void (*uv_shutdown_cb)(uv_shutdown_t* req, int status);
+typedef void (*uv_connection_cb)(uv_stream_t* server, int status);
+typedef void (*uv_close_cb)(uv_handle_t* handle);
+typedef void (*uv_poll_cb)(uv_poll_t* handle, int status, int events);
+typedef void (*uv_timer_cb)(uv_timer_t* handle);
+typedef void (*uv_async_cb)(uv_async_t* handle);
+typedef void (*uv_prepare_cb)(uv_prepare_t* handle);
+typedef void (*uv_check_cb)(uv_check_t* handle);
+typedef void (*uv_idle_cb)(uv_idle_t* handle);
+typedef void (*uv_exit_cb)(uv_process_t*, int64_t exit_status, int term_signal);
+typedef void (*uv_walk_cb)(uv_handle_t* handle, void* arg);
+typedef void (*uv_fs_cb)(uv_fs_t* req);
+typedef void (*uv_work_cb)(uv_work_t* req);
+typedef void (*uv_after_work_cb)(uv_work_t* req, int status);
+typedef void (*uv_getaddrinfo_cb)(uv_getaddrinfo_t* req,
+                                  int status,
+                                  struct addrinfo* res);
+typedef void (*uv_getnameinfo_cb)(uv_getnameinfo_t* req,
+                                  int status,
+                                  const char* hostname,
+                                  const char* service);
+typedef void (*uv_random_cb)(uv_random_t* req,
+                             int status,
+                             void* buf,
+                             size_t buflen);
+
+typedef enum {
+  UV_CLOCK_MONOTONIC,
+  UV_CLOCK_REALTIME
+} uv_clock_id;
+
+/* XXX(bnoordhuis) not 2038-proof, https://github.com/libuv/libuv/issues/3864 */
+typedef struct {
+  long tv_sec;
+  long tv_nsec;
+} uv_timespec_t;
+
+typedef struct {
+  int64_t tv_sec;
+  int32_t tv_nsec;
+} uv_timespec64_t;
+
+/* XXX(bnoordhuis) not 2038-proof, https://github.com/libuv/libuv/issues/3864 */
+typedef struct {
+  long tv_sec;
+  long tv_usec;
+} uv_timeval_t;
+
+typedef struct {
+  int64_t tv_sec;
+  int32_t tv_usec;
+} uv_timeval64_t;
+
+typedef struct {
+  uint64_t st_dev;
+  uint64_t st_mode;
+  uint64_t st_nlink;
+  uint64_t st_uid;
+  uint64_t st_gid;
+  uint64_t st_rdev;
+  uint64_t st_ino;
+  uint64_t st_size;
+  uint64_t st_blksize;
+  uint64_t st_blocks;
+  uint64_t st_flags;
+  uint64_t st_gen;
+  uv_timespec_t st_atim;
+  uv_timespec_t st_mtim;
+  uv_timespec_t st_ctim;
+  uv_timespec_t st_birthtim;
+} uv_stat_t;
+
+
+typedef void (*uv_fs_event_cb)(uv_fs_event_t* handle,
+                               const char* filename,
+                               int events,
+                               int status);
+
+typedef void (*uv_fs_poll_cb)(uv_fs_poll_t* handle,
+                              int status,
+                              const uv_stat_t* prev,
+                              const uv_stat_t* curr);
+
+typedef void (*uv_signal_cb)(uv_signal_t* handle, int signum);
+
+
+typedef enum {
+  UV_LEAVE_GROUP = 0,
+  UV_JOIN_GROUP
+} uv_membership;
+
+
+UV_EXTERN int uv_translate_sys_error(int sys_errno);
+
+UV_EXTERN const char* uv_strerror(int err);
+UV_EXTERN char* uv_strerror_r(int err, char* buf, size_t buflen);
+
+UV_EXTERN const char* uv_err_name(int err);
+UV_EXTERN char* uv_err_name_r(int err, char* buf, size_t buflen);
+
+
+#define UV_REQ_FIELDS                                                         \
+  /* public */                                                                \
+  void* data;                                                                 \
+  /* read-only */                                                             \
+  uv_req_type type;                                                           \
+  /* private */                                                               \
+  void* reserved[6];                                                          \
+  UV_REQ_PRIVATE_FIELDS                                                       \
+
+/* Abstract base class of all requests. */
+struct uv_req_s {
+  UV_REQ_FIELDS
+};
+
+
+/* Platform-specific request types. */
+UV_PRIVATE_REQ_TYPES
+
+
+UV_EXTERN int uv_shutdown(uv_shutdown_t* req,
+                          uv_stream_t* handle,
+                          uv_shutdown_cb cb);
+
+struct uv_shutdown_s {
+  UV_REQ_FIELDS
+  uv_stream_t* handle;
+  uv_shutdown_cb cb;
+  UV_SHUTDOWN_PRIVATE_FIELDS
+};
+
+
+#define UV_HANDLE_FIELDS                                                      \
+  /* public */                                                                \
+  void* data;                                                                 \
+  /* read-only */                                                             \
+  uv_loop_t* loop;                                                            \
+  uv_handle_type type;                                                        \
+  /* private */                                                               \
+  uv_close_cb close_cb;                                                       \
+  struct uv__queue handle_queue;                                              \
+  union {                                                                     \
+    int fd;                                                                   \
+    void* reserved[4];                                                        \
+  } u;                                                                        \
+  UV_HANDLE_PRIVATE_FIELDS                                                    \
+
+/* The abstract base class of all handles. */
+struct uv_handle_s {
+  UV_HANDLE_FIELDS
+};
+
+UV_EXTERN size_t uv_handle_size(uv_handle_type type);
+UV_EXTERN uv_handle_type uv_handle_get_type(const uv_handle_t* handle);
+UV_EXTERN const char* uv_handle_type_name(uv_handle_type type);
+UV_EXTERN void* uv_handle_get_data(const uv_handle_t* handle);
+UV_EXTERN uv_loop_t* uv_handle_get_loop(const uv_handle_t* handle);
+UV_EXTERN void uv_handle_set_data(uv_handle_t* handle, void* data);
+
+UV_EXTERN size_t uv_req_size(uv_req_type type);
+UV_EXTERN void* uv_req_get_data(const uv_req_t* req);
+UV_EXTERN void uv_req_set_data(uv_req_t* req, void* data);
+UV_EXTERN uv_req_type uv_req_get_type(const uv_req_t* req);
+UV_EXTERN const char* uv_req_type_name(uv_req_type type);
+
+UV_EXTERN int uv_is_active(const uv_handle_t* handle);
+
+UV_EXTERN void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg);
+
+/* Helpers for ad hoc debugging, no API/ABI stability guaranteed. */
+UV_EXTERN void uv_print_all_handles(uv_loop_t* loop, FILE* stream);
+UV_EXTERN void uv_print_active_handles(uv_loop_t* loop, FILE* stream);
+
+UV_EXTERN void uv_close(uv_handle_t* handle, uv_close_cb close_cb);
+
+UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value);
+UV_EXTERN int uv_recv_buffer_size(uv_handle_t* handle, int* value);
+
+UV_EXTERN int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd);
+
+UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
+
+UV_EXTERN int uv_pipe(uv_file fds[2], int read_flags, int write_flags);
+UV_EXTERN int uv_socketpair(int type,
+                            int protocol,
+                            uv_os_sock_t socket_vector[2],
+                            int flags0,
+                            int flags1);
+
+#define UV_STREAM_FIELDS                                                      \
+  /* number of bytes queued for writing */                                    \
+  size_t write_queue_size;                                                    \
+  uv_alloc_cb alloc_cb;                                                       \
+  uv_read_cb read_cb;                                                         \
+  /* private */                                                               \
+  UV_STREAM_PRIVATE_FIELDS
+
+/*
+ * uv_stream_t is a subclass of uv_handle_t.
+ *
+ * uv_stream is an abstract class.
+ *
+ * uv_stream_t is the parent class of uv_tcp_t, uv_pipe_t and uv_tty_t.
+ */
+struct uv_stream_s {
+  UV_HANDLE_FIELDS
+  UV_STREAM_FIELDS
+};
+
+UV_EXTERN size_t uv_stream_get_write_queue_size(const uv_stream_t* stream);
+
+UV_EXTERN int uv_listen(uv_stream_t* stream, int backlog, uv_connection_cb cb);
+UV_EXTERN int uv_accept(uv_stream_t* server, uv_stream_t* client);
+
+UV_EXTERN int uv_read_start(uv_stream_t*,
+                            uv_alloc_cb alloc_cb,
+                            uv_read_cb read_cb);
+UV_EXTERN int uv_read_stop(uv_stream_t*);
+
+UV_EXTERN int uv_write(uv_write_t* req,
+                       uv_stream_t* handle,
+                       const uv_buf_t bufs[],
+                       unsigned int nbufs,
+                       uv_write_cb cb);
+UV_EXTERN int uv_write2(uv_write_t* req,
+                        uv_stream_t* handle,
+                        const uv_buf_t bufs[],
+                        unsigned int nbufs,
+                        uv_stream_t* send_handle,
+                        uv_write_cb cb);
+UV_EXTERN int uv_try_write(uv_stream_t* handle,
+                           const uv_buf_t bufs[],
+                           unsigned int nbufs);
+UV_EXTERN int uv_try_write2(uv_stream_t* handle,
+                            const uv_buf_t bufs[],
+                            unsigned int nbufs,
+                            uv_stream_t* send_handle);
+
+/* uv_write_t is a subclass of uv_req_t. */
+struct uv_write_s {
+  UV_REQ_FIELDS
+  uv_write_cb cb;
+  uv_stream_t* send_handle; /* TODO: make private and unix-only in v2.x. */
+  uv_stream_t* handle;
+  UV_WRITE_PRIVATE_FIELDS
+};
+
+
+UV_EXTERN int uv_is_readable(const uv_stream_t* handle);
+UV_EXTERN int uv_is_writable(const uv_stream_t* handle);
+
+UV_EXTERN int uv_stream_set_blocking(uv_stream_t* handle, int blocking);
+
+UV_EXTERN int uv_is_closing(const uv_handle_t* handle);
+
+
+/*
+ * uv_tcp_t is a subclass of uv_stream_t.
+ *
+ * Represents a TCP stream or TCP server.
+ */
+struct uv_tcp_s {
+  UV_HANDLE_FIELDS
+  UV_STREAM_FIELDS
+  UV_TCP_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_tcp_init(uv_loop_t*, uv_tcp_t* handle);
+UV_EXTERN int uv_tcp_init_ex(uv_loop_t*, uv_tcp_t* handle, unsigned int flags);
+UV_EXTERN int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock);
+UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
+UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle,
+                               int enable,
+                               unsigned int delay);
+UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
+
+enum uv_tcp_flags {
+  /* Used with uv_tcp_bind, when an IPv6 address is used. */
+  UV_TCP_IPV6ONLY = 1,
+
+  /* Enable SO_REUSEPORT socket option when binding the handle.
+   * This allows completely duplicate bindings by multiple processes
+   * or threads if they all set SO_REUSEPORT before binding the port.
+   * Incoming connections are distributed across the participating
+   * listener sockets.
+   *
+   * This flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+   * FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+ for now.
+   */
+  UV_TCP_REUSEPORT = 2,
+};
+
+UV_EXTERN int uv_tcp_bind(uv_tcp_t* handle,
+                          const struct sockaddr* addr,
+                          unsigned int flags);
+UV_EXTERN int uv_tcp_getsockname(const uv_tcp_t* handle,
+                                 struct sockaddr* name,
+                                 int* namelen);
+UV_EXTERN int uv_tcp_getpeername(const uv_tcp_t* handle,
+                                 struct sockaddr* name,
+                                 int* namelen);
+UV_EXTERN int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb);
+UV_EXTERN int uv_tcp_connect(uv_connect_t* req,
+                             uv_tcp_t* handle,
+                             const struct sockaddr* addr,
+                             uv_connect_cb cb);
+
+/* uv_connect_t is a subclass of uv_req_t. */
+struct uv_connect_s {
+  UV_REQ_FIELDS
+  uv_connect_cb cb;
+  uv_stream_t* handle;
+  UV_CONNECT_PRIVATE_FIELDS
+};
+
+
+/*
+ * UDP support.
+ */
+
+enum uv_udp_flags {
+  /* Disables dual stack mode. */
+  UV_UDP_IPV6ONLY = 1,
+  /*
+   * Indicates message was truncated because read buffer was too small. The
+   * remainder was discarded by the OS. Used in uv_udp_recv_cb.
+   */
+  UV_UDP_PARTIAL = 2,
+  /*
+   * Indicates if SO_REUSEADDR will be set when binding the handle.
+   * This sets the SO_REUSEPORT socket flag on the BSDs (except for
+   * DragonFlyBSD), OS X, and other platforms where SO_REUSEPORTs don't
+   * have the capability of load balancing, as the opposite of what
+   * UV_UDP_REUSEPORT would do. On other Unix platforms, it sets the
+   * SO_REUSEADDR flag. What that means is that multiple threads or
+   * processes can bind to the same address without error (provided
+   * they all set the flag) but only the last one to bind will receive
+   * any traffic, in effect "stealing" the port from the previous listener.
+   */
+  UV_UDP_REUSEADDR = 4,
+  /*
+   * Indicates that the message was received by recvmmsg, so the buffer provided
+   * must not be freed by the recv_cb callback.
+   */
+  UV_UDP_MMSG_CHUNK = 8,
+  /*
+   * Indicates that the buffer provided has been fully utilized by recvmmsg and
+   * that it should now be freed by the recv_cb callback. When this flag is set
+   * in uv_udp_recv_cb, nread will always be 0 and addr will always be NULL.
+   */
+  UV_UDP_MMSG_FREE = 16,
+  /*
+   * Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+   * This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+   * Linux. This stops the Linux kernel from suppressing some ICMP error
+   * messages and enables full ICMP error reporting for faster failover.
+   * This flag is no-op on platforms other than Linux.
+   */
+  UV_UDP_LINUX_RECVERR = 32,
+  /*
+   * Indicates if SO_REUSEPORT will be set when binding the handle.
+   * This sets the SO_REUSEPORT socket option on supported platforms.
+   * Unlike UV_UDP_REUSEADDR, this flag will make multiple threads or
+   * processes that are binding to the same address and port "share"
+   * the port, which means incoming datagrams are distributed across
+   * the receiving sockets among threads or processes.
+   *
+   * This flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+   * FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+ for now.
+   */
+  UV_UDP_REUSEPORT = 64,
+  /*
+   * Indicates that recvmmsg should be used, if available.
+   */
+  UV_UDP_RECVMMSG = 256
+};
+
+typedef void (*uv_udp_send_cb)(uv_udp_send_t* req, int status);
+typedef void (*uv_udp_recv_cb)(uv_udp_t* handle,
+                               ssize_t nread,
+                               const uv_buf_t* buf,
+                               const struct sockaddr* addr,
+                               unsigned flags);
+
+/* uv_udp_t is a subclass of uv_handle_t. */
+struct uv_udp_s {
+  UV_HANDLE_FIELDS
+  /* read-only */
+  /*
+   * Number of bytes queued for sending. This field strictly shows how much
+   * information is currently queued.
+   */
+  size_t send_queue_size;
+  /*
+   * Number of send requests currently in the queue awaiting to be processed.
+   */
+  size_t send_queue_count;
+  UV_UDP_PRIVATE_FIELDS
+};
+
+/* uv_udp_send_t is a subclass of uv_req_t. */
+struct uv_udp_send_s {
+  UV_REQ_FIELDS
+  uv_udp_t* handle;
+  uv_udp_send_cb cb;
+  UV_UDP_SEND_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_udp_init(uv_loop_t*, uv_udp_t* handle);
+UV_EXTERN int uv_udp_init_ex(uv_loop_t*, uv_udp_t* handle, unsigned int flags);
+UV_EXTERN int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock);
+UV_EXTERN int uv_udp_bind(uv_udp_t* handle,
+                          const struct sockaddr* addr,
+                          unsigned int flags);
+UV_EXTERN int uv_udp_connect(uv_udp_t* handle, const struct sockaddr* addr);
+
+UV_EXTERN int uv_udp_getpeername(const uv_udp_t* handle,
+                                 struct sockaddr* name,
+                                 int* namelen);
+UV_EXTERN int uv_udp_getsockname(const uv_udp_t* handle,
+                                 struct sockaddr* name,
+                                 int* namelen);
+UV_EXTERN int uv_udp_set_membership(uv_udp_t* handle,
+                                    const char* multicast_addr,
+                                    const char* interface_addr,
+                                    uv_membership membership);
+UV_EXTERN int uv_udp_set_source_membership(uv_udp_t* handle,
+                                           const char* multicast_addr,
+                                           const char* interface_addr,
+                                           const char* source_addr,
+                                           uv_membership membership);
+UV_EXTERN int uv_udp_set_multicast_loop(uv_udp_t* handle, int on);
+UV_EXTERN int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl);
+UV_EXTERN int uv_udp_set_multicast_interface(uv_udp_t* handle,
+                                             const char* interface_addr);
+UV_EXTERN int uv_udp_set_broadcast(uv_udp_t* handle, int on);
+UV_EXTERN int uv_udp_set_ttl(uv_udp_t* handle, int ttl);
+UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
+                          uv_udp_t* handle,
+                          const uv_buf_t bufs[],
+                          unsigned int nbufs,
+                          const struct sockaddr* addr,
+                          uv_udp_send_cb send_cb);
+UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
+                              const uv_buf_t bufs[],
+                              unsigned int nbufs,
+                              const struct sockaddr* addr);
+UV_EXTERN int uv_udp_recv_start(uv_udp_t* handle,
+                                uv_alloc_cb alloc_cb,
+                                uv_udp_recv_cb recv_cb);
+UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
+UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
+UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
+UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);
+
+
+/*
+ * uv_tty_t is a subclass of uv_stream_t.
+ *
+ * Representing a stream for the console.
+ */
+struct uv_tty_s {
+  UV_HANDLE_FIELDS
+  UV_STREAM_FIELDS
+  UV_TTY_PRIVATE_FIELDS
+};
+
+typedef enum {
+  /* Initial/normal terminal mode */
+  UV_TTY_MODE_NORMAL,
+  /* Raw input mode (On Windows, ENABLE_WINDOW_INPUT is also enabled) */
+  UV_TTY_MODE_RAW,
+  /* Binary-safe I/O mode for IPC (Unix-only) */
+  UV_TTY_MODE_IO
+} uv_tty_mode_t;
+
+typedef enum {
+  /*
+   * The console supports handling of virtual terminal sequences
+   * (Windows10 new console, ConEmu)
+   */
+  UV_TTY_SUPPORTED,
+  /* The console cannot process the virtual terminal sequence.  (Legacy
+   * console)
+   */
+  UV_TTY_UNSUPPORTED
+} uv_tty_vtermstate_t;
+
+
+UV_EXTERN int uv_tty_init(uv_loop_t*, uv_tty_t*, uv_file fd, int readable);
+UV_EXTERN int uv_tty_set_mode(uv_tty_t*, uv_tty_mode_t mode);
+UV_EXTERN int uv_tty_reset_mode(void);
+UV_EXTERN int uv_tty_get_winsize(uv_tty_t*, int* width, int* height);
+UV_EXTERN void uv_tty_set_vterm_state(uv_tty_vtermstate_t state);
+UV_EXTERN int uv_tty_get_vterm_state(uv_tty_vtermstate_t* state);
+
+#ifdef __cplusplus
+extern "C++" {
+
+inline int uv_tty_set_mode(uv_tty_t* handle, int mode) {
+  return uv_tty_set_mode(handle, static_cast<uv_tty_mode_t>(mode));
+}
+
+}
+#endif
+
+UV_EXTERN uv_handle_type uv_guess_handle(uv_file file);
+
+enum {
+  UV_PIPE_NO_TRUNCATE = 1u << 0
+};
+
+/*
+ * uv_pipe_t is a subclass of uv_stream_t.
+ *
+ * Representing a pipe stream or pipe server. On Windows this is a Named
+ * Pipe. On Unix this is a Unix domain socket.
+ */
+struct uv_pipe_s {
+  UV_HANDLE_FIELDS
+  UV_STREAM_FIELDS
+  int ipc; /* non-zero if this pipe is used for passing handles */
+  UV_PIPE_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_pipe_init(uv_loop_t*, uv_pipe_t* handle, int ipc);
+UV_EXTERN int uv_pipe_open(uv_pipe_t*, uv_file file);
+UV_EXTERN int uv_pipe_bind(uv_pipe_t* handle, const char* name);
+UV_EXTERN int uv_pipe_bind2(uv_pipe_t* handle,
+                            const char* name,
+                            size_t namelen,
+                            unsigned int flags);
+UV_EXTERN void uv_pipe_connect(uv_connect_t* req,
+                               uv_pipe_t* handle,
+                               const char* name,
+                               uv_connect_cb cb);
+UV_EXTERN int uv_pipe_connect2(uv_connect_t* req,
+                               uv_pipe_t* handle,
+                               const char* name,
+                               size_t namelen,
+                               unsigned int flags,
+                               uv_connect_cb cb);
+UV_EXTERN int uv_pipe_getsockname(const uv_pipe_t* handle,
+                                  char* buffer,
+                                  size_t* size);
+UV_EXTERN int uv_pipe_getpeername(const uv_pipe_t* handle,
+                                  char* buffer,
+                                  size_t* size);
+UV_EXTERN void uv_pipe_pending_instances(uv_pipe_t* handle, int count);
+UV_EXTERN int uv_pipe_pending_count(uv_pipe_t* handle);
+UV_EXTERN uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle);
+UV_EXTERN int uv_pipe_chmod(uv_pipe_t* handle, int flags);
+
+
+struct uv_poll_s {
+  UV_HANDLE_FIELDS
+  uv_poll_cb poll_cb;
+  UV_POLL_PRIVATE_FIELDS
+};
+
+enum uv_poll_event {
+  UV_READABLE = 1,
+  UV_WRITABLE = 2,
+  UV_DISCONNECT = 4,
+  UV_PRIORITIZED = 8
+};
+
+UV_EXTERN int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd);
+UV_EXTERN int uv_poll_init_socket(uv_loop_t* loop,
+                                  uv_poll_t* handle,
+                                  uv_os_sock_t socket);
+UV_EXTERN int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb);
+UV_EXTERN int uv_poll_stop(uv_poll_t* handle);
+
+
+struct uv_prepare_s {
+  UV_HANDLE_FIELDS
+  UV_PREPARE_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_prepare_init(uv_loop_t*, uv_prepare_t* prepare);
+UV_EXTERN int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb);
+UV_EXTERN int uv_prepare_stop(uv_prepare_t* prepare);
+
+
+struct uv_check_s {
+  UV_HANDLE_FIELDS
+  UV_CHECK_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_check_init(uv_loop_t*, uv_check_t* check);
+UV_EXTERN int uv_check_start(uv_check_t* check, uv_check_cb cb);
+UV_EXTERN int uv_check_stop(uv_check_t* check);
+
+
+struct uv_idle_s {
+  UV_HANDLE_FIELDS
+  UV_IDLE_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_idle_init(uv_loop_t*, uv_idle_t* idle);
+UV_EXTERN int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb);
+UV_EXTERN int uv_idle_stop(uv_idle_t* idle);
+
+
+struct uv_async_s {
+  UV_HANDLE_FIELDS
+  UV_ASYNC_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_async_init(uv_loop_t*,
+                            uv_async_t* async,
+                            uv_async_cb async_cb);
+UV_EXTERN int uv_async_send(uv_async_t* async);
+
+
+/*
+ * uv_timer_t is a subclass of uv_handle_t.
+ *
+ * Used to get woken up at a specified time in the future.
+ */
+struct uv_timer_s {
+  UV_HANDLE_FIELDS
+  UV_TIMER_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_timer_init(uv_loop_t*, uv_timer_t* handle);
+UV_EXTERN int uv_timer_start(uv_timer_t* handle,
+                             uv_timer_cb cb,
+                             uint64_t timeout,
+                             uint64_t repeat);
+UV_EXTERN int uv_timer_stop(uv_timer_t* handle);
+UV_EXTERN int uv_timer_again(uv_timer_t* handle);
+UV_EXTERN void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat);
+UV_EXTERN uint64_t uv_timer_get_repeat(const uv_timer_t* handle);
+UV_EXTERN uint64_t uv_timer_get_due_in(const uv_timer_t* handle);
+
+
+/*
+ * uv_getaddrinfo_t is a subclass of uv_req_t.
+ *
+ * Request object for uv_getaddrinfo.
+ */
+struct uv_getaddrinfo_s {
+  UV_REQ_FIELDS
+  /* read-only */
+  uv_loop_t* loop;
+  /* struct addrinfo* addrinfo is marked as private, but it really isn't. */
+  UV_GETADDRINFO_PRIVATE_FIELDS
+};
+
+
+UV_EXTERN int uv_getaddrinfo(uv_loop_t* loop,
+                             uv_getaddrinfo_t* req,
+                             uv_getaddrinfo_cb getaddrinfo_cb,
+                             const char* node,
+                             const char* service,
+                             const struct addrinfo* hints);
+UV_EXTERN void uv_freeaddrinfo(struct addrinfo* ai);
+
+
+/*
+* uv_getnameinfo_t is a subclass of uv_req_t.
+*
+* Request object for uv_getnameinfo.
+*/
+struct uv_getnameinfo_s {
+  UV_REQ_FIELDS
+  /* read-only */
+  uv_loop_t* loop;
+  /* host and service are marked as private, but they really aren't. */
+  UV_GETNAMEINFO_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_getnameinfo(uv_loop_t* loop,
+                             uv_getnameinfo_t* req,
+                             uv_getnameinfo_cb getnameinfo_cb,
+                             const struct sockaddr* addr,
+                             int flags);
+
+
+/* uv_spawn() options. */
+typedef enum {
+  UV_IGNORE         = 0x00,
+  UV_CREATE_PIPE    = 0x01,
+  UV_INHERIT_FD     = 0x02,
+  UV_INHERIT_STREAM = 0x04,
+
+  /*
+   * When UV_CREATE_PIPE is specified, UV_READABLE_PIPE and UV_WRITABLE_PIPE
+   * determine the direction of flow, from the child process' perspective. Both
+   * flags may be specified to create a duplex data stream.
+   */
+  UV_READABLE_PIPE  = 0x10,
+  UV_WRITABLE_PIPE  = 0x20,
+
+  /*
+   * When UV_CREATE_PIPE is specified, specifying UV_NONBLOCK_PIPE opens the
+   * handle in non-blocking mode in the child. This may cause loss of data,
+   * if the child is not designed to handle to encounter this mode,
+   * but can also be significantly more efficient.
+   */
+  UV_NONBLOCK_PIPE  = 0x40,
+  UV_OVERLAPPED_PIPE = 0x40 /* old name, for compatibility */
+} uv_stdio_flags;
+
+typedef struct uv_stdio_container_s {
+  uv_stdio_flags flags;
+
+  union {
+    uv_stream_t* stream;
+    int fd;
+  } data;
+} uv_stdio_container_t;
+
+typedef struct uv_process_options_s {
+  uv_exit_cb exit_cb; /* Called after the process exits. */
+  const char* file;   /* Path to program to execute. */
+  /*
+   * Command line arguments. args[0] should be the path to the program. On
+   * Windows this uses CreateProcess which concatenates the arguments into a
+   * string this can cause some strange errors. See the note at
+   * windows_verbatim_arguments.
+   */
+  char** args;
+  /*
+   * This will be set as the environ variable in the subprocess. If this is
+   * NULL then the parents environ will be used.
+   */
+  char** env;
+  /*
+   * If non-null this represents a directory the subprocess should execute
+   * in. Stands for current working directory.
+   */
+  const char* cwd;
+  /*
+   * Various flags that control how uv_spawn() behaves. See the definition of
+   * `enum uv_process_flags` below.
+   */
+  unsigned int flags;
+  /*
+   * The `stdio` field points to an array of uv_stdio_container_t structs that
+   * describe the file descriptors that will be made available to the child
+   * process. The convention is that stdio[0] points to stdin, fd 1 is used for
+   * stdout, and fd 2 is stderr.
+   *
+   * Note that on windows file descriptors greater than 2 are available to the
+   * child process only if the child processes uses the MSVCRT runtime.
+   */
+  int stdio_count;
+  uv_stdio_container_t* stdio;
+  /*
+   * Libuv can change the child process' user/group id. This happens only when
+   * the appropriate bits are set in the flags fields. This is not supported on
+   * windows; uv_spawn() will fail and set the error to UV_ENOTSUP.
+   */
+  uv_uid_t uid;
+  uv_gid_t gid;
+} uv_process_options_t;
+
+/*
+ * These are the flags that can be used for the uv_process_options.flags field.
+ */
+enum uv_process_flags {
+  /*
+   * Set the child process' user id. The user id is supplied in the `uid` field
+   * of the options struct. This does not work on windows; setting this flag
+   * will cause uv_spawn() to fail.
+   */
+  UV_PROCESS_SETUID = (1 << 0),
+  /*
+   * Set the child process' group id. The user id is supplied in the `gid`
+   * field of the options struct. This does not work on windows; setting this
+   * flag will cause uv_spawn() to fail.
+   */
+  UV_PROCESS_SETGID = (1 << 1),
+  /*
+   * Do not wrap any arguments in quotes, or perform any other escaping, when
+   * converting the argument list into a command line string. This option is
+   * only meaningful on Windows systems. On Unix it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS = (1 << 2),
+  /*
+   * Spawn the child process in a detached state - this will make it a process
+   * group leader, and will effectively enable the child to keep running after
+   * the parent exits.  Note that the child process will still keep the
+   * parent's event loop alive unless the parent process calls uv_unref() on
+   * the child's process handle.
+   */
+  UV_PROCESS_DETACHED = (1 << 3),
+  /*
+   * Hide the subprocess window that would normally be created. This option is
+   * only meaningful on Windows systems. On Unix it is silently ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE = (1 << 4),
+  /*
+   * Hide the subprocess console window that would normally be created. This
+   * option is only meaningful on Windows systems. On Unix it is silently
+   * ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE_CONSOLE = (1 << 5),
+  /*
+   * Hide the subprocess GUI window that would normally be created. This
+   * option is only meaningful on Windows systems. On Unix it is silently
+   * ignored.
+   */
+  UV_PROCESS_WINDOWS_HIDE_GUI = (1 << 6),
+  /*
+   * On Windows, if the path to the program to execute, specified in
+   * uv_process_options_t's file field, has a directory component,
+   * search for the exact file name before trying variants with
+   * extensions like '.exe' or '.cmd'.
+   */
+  UV_PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = (1 << 7)
+};
+
+/*
+ * uv_process_t is a subclass of uv_handle_t.
+ */
+struct uv_process_s {
+  UV_HANDLE_FIELDS
+  uv_exit_cb exit_cb;
+  int pid;
+  UV_PROCESS_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_spawn(uv_loop_t* loop,
+                       uv_process_t* handle,
+                       const uv_process_options_t* options);
+UV_EXTERN int uv_process_kill(uv_process_t*, int signum);
+UV_EXTERN int uv_kill(int pid, int signum);
+UV_EXTERN uv_pid_t uv_process_get_pid(const uv_process_t*);
+
+
+/*
+ * uv_work_t is a subclass of uv_req_t.
+ */
+struct uv_work_s {
+  UV_REQ_FIELDS
+  uv_loop_t* loop;
+  uv_work_cb work_cb;
+  uv_after_work_cb after_work_cb;
+  UV_WORK_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_queue_work(uv_loop_t* loop,
+                            uv_work_t* req,
+                            uv_work_cb work_cb,
+                            uv_after_work_cb after_work_cb);
+
+UV_EXTERN int uv_cancel(uv_req_t* req);
+
+
+struct uv_cpu_times_s {
+  uint64_t user; /* milliseconds */
+  uint64_t nice; /* milliseconds */
+  uint64_t sys; /* milliseconds */
+  uint64_t idle; /* milliseconds */
+  uint64_t irq; /* milliseconds */
+};
+
+struct uv_cpu_info_s {
+  char* model;
+  int speed;
+  struct uv_cpu_times_s cpu_times;
+};
+
+struct uv_interface_address_s {
+  char* name;
+  char phys_addr[6];
+  int is_internal;
+  union {
+    struct sockaddr_in address4;
+    struct sockaddr_in6 address6;
+  } address;
+  union {
+    struct sockaddr_in netmask4;
+    struct sockaddr_in6 netmask6;
+  } netmask;
+};
+
+struct uv_passwd_s {
+  char* username;
+  unsigned long uid;
+  unsigned long gid;
+  char* shell;
+  char* homedir;
+};
+
+struct uv_group_s {
+  char* groupname;
+  unsigned long gid;
+  char** members;
+};
+
+struct uv_utsname_s {
+  char sysname[256];
+  char release[256];
+  char version[256];
+  char machine[256];
+  /* This struct does not contain the nodename and domainname fields present in
+     the utsname type. domainname is a GNU extension. Both fields are referred
+     to as meaningless in the docs. */
+};
+
+struct uv_statfs_s {
+  uint64_t f_type;
+  uint64_t f_bsize;
+  uint64_t f_blocks;
+  uint64_t f_bfree;
+  uint64_t f_bavail;
+  uint64_t f_files;
+  uint64_t f_ffree;
+  uint64_t f_spare[4];
+};
+
+typedef enum {
+  UV_DIRENT_UNKNOWN,
+  UV_DIRENT_FILE,
+  UV_DIRENT_DIR,
+  UV_DIRENT_LINK,
+  UV_DIRENT_FIFO,
+  UV_DIRENT_SOCKET,
+  UV_DIRENT_CHAR,
+  UV_DIRENT_BLOCK
+} uv_dirent_type_t;
+
+struct uv_dirent_s {
+  const char* name;
+  uv_dirent_type_t type;
+};
+
+UV_EXTERN char** uv_setup_args(int argc, char** argv);
+UV_EXTERN int uv_get_process_title(char* buffer, size_t size);
+UV_EXTERN int uv_set_process_title(const char* title);
+UV_EXTERN int uv_resident_set_memory(size_t* rss);
+UV_EXTERN int uv_uptime(double* uptime);
+UV_EXTERN uv_os_fd_t uv_get_osfhandle(int fd);
+UV_EXTERN int uv_open_osfhandle(uv_os_fd_t os_fd);
+
+typedef struct {
+   uv_timeval_t ru_utime; /* user CPU time used */
+   uv_timeval_t ru_stime; /* system CPU time used */
+   uint64_t ru_maxrss;    /* maximum resident set size */
+   uint64_t ru_ixrss;     /* integral shared memory size */
+   uint64_t ru_idrss;     /* integral unshared data size */
+   uint64_t ru_isrss;     /* integral unshared stack size */
+   uint64_t ru_minflt;    /* page reclaims (soft page faults) */
+   uint64_t ru_majflt;    /* page faults (hard page faults) */
+   uint64_t ru_nswap;     /* swaps */
+   uint64_t ru_inblock;   /* block input operations */
+   uint64_t ru_oublock;   /* block output operations */
+   uint64_t ru_msgsnd;    /* IPC messages sent */
+   uint64_t ru_msgrcv;    /* IPC messages received */
+   uint64_t ru_nsignals;  /* signals received */
+   uint64_t ru_nvcsw;     /* voluntary context switches */
+   uint64_t ru_nivcsw;    /* involuntary context switches */
+} uv_rusage_t;
+
+UV_EXTERN int uv_getrusage(uv_rusage_t* rusage);
+
+UV_EXTERN int uv_os_homedir(char* buffer, size_t* size);
+UV_EXTERN int uv_os_tmpdir(char* buffer, size_t* size);
+UV_EXTERN int uv_os_get_passwd(uv_passwd_t* pwd);
+UV_EXTERN void uv_os_free_passwd(uv_passwd_t* pwd);
+UV_EXTERN int uv_os_get_passwd2(uv_passwd_t* pwd, uv_uid_t uid);
+UV_EXTERN int uv_os_get_group(uv_group_t* grp, uv_uid_t gid);
+UV_EXTERN void uv_os_free_group(uv_group_t* grp);
+UV_EXTERN uv_pid_t uv_os_getpid(void);
+UV_EXTERN uv_pid_t uv_os_getppid(void);
+
+#if defined(__PASE__)
+/* On IBM i PASE, the highest process priority is -10 */
+# define UV_PRIORITY_LOW 39          /* RUNPTY(99) */
+# define UV_PRIORITY_BELOW_NORMAL 15 /* RUNPTY(50) */
+# define UV_PRIORITY_NORMAL 0        /* RUNPTY(20) */
+# define UV_PRIORITY_ABOVE_NORMAL -4 /* RUNTY(12) */
+# define UV_PRIORITY_HIGH -7         /* RUNPTY(6) */
+# define UV_PRIORITY_HIGHEST -10     /* RUNPTY(1) */
+#else
+# define UV_PRIORITY_LOW 19
+# define UV_PRIORITY_BELOW_NORMAL 10
+# define UV_PRIORITY_NORMAL 0
+# define UV_PRIORITY_ABOVE_NORMAL -7
+# define UV_PRIORITY_HIGH -14
+# define UV_PRIORITY_HIGHEST -20
+#endif
+
+UV_EXTERN int uv_os_getpriority(uv_pid_t pid, int* priority);
+UV_EXTERN int uv_os_setpriority(uv_pid_t pid, int priority);
+
+enum {
+  UV_THREAD_PRIORITY_HIGHEST = 2,
+  UV_THREAD_PRIORITY_ABOVE_NORMAL = 1,
+  UV_THREAD_PRIORITY_NORMAL = 0,
+  UV_THREAD_PRIORITY_BELOW_NORMAL = -1,
+  UV_THREAD_PRIORITY_LOWEST = -2,
+};
+
+UV_EXTERN int uv_thread_getpriority(uv_thread_t tid, int* priority);
+UV_EXTERN int uv_thread_setpriority(uv_thread_t tid, int priority);
+
+UV_EXTERN unsigned int uv_available_parallelism(void);
+UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);
+UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);
+UV_EXTERN int uv_cpumask_size(void);
+
+UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses,
+                                     int* count);
+UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
+                                           int count);
+
+struct uv_env_item_s {
+  char* name;
+  char* value;
+};
+
+UV_EXTERN int uv_os_environ(uv_env_item_t** envitems, int* count);
+UV_EXTERN void uv_os_free_environ(uv_env_item_t* envitems, int count);
+UV_EXTERN int uv_os_getenv(const char* name, char* buffer, size_t* size);
+UV_EXTERN int uv_os_setenv(const char* name, const char* value);
+UV_EXTERN int uv_os_unsetenv(const char* name);
+
+#ifdef MAXHOSTNAMELEN
+# define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
+#else
+  /*
+    Fallback for the maximum hostname size, including the null terminator. The
+    Windows gethostname() documentation states that 256 bytes will always be
+    large enough to hold the null-terminated hostname.
+  */
+# define UV_MAXHOSTNAMESIZE 256
+#endif
+
+UV_EXTERN int uv_os_gethostname(char* buffer, size_t* size);
+
+UV_EXTERN int uv_os_uname(uv_utsname_t* buffer);
+
+struct uv_metrics_s {
+  uint64_t loop_count;
+  uint64_t events;
+  uint64_t events_waiting;
+  /* private */
+  uint64_t* reserved[13];
+};
+
+UV_EXTERN int uv_metrics_info(uv_loop_t* loop, uv_metrics_t* metrics);
+UV_EXTERN uint64_t uv_metrics_idle_time(uv_loop_t* loop);
+
+typedef enum {
+  UV_FS_UNKNOWN = -1,
+  UV_FS_CUSTOM,
+  UV_FS_OPEN,
+  UV_FS_CLOSE,
+  UV_FS_READ,
+  UV_FS_WRITE,
+  UV_FS_SENDFILE,
+  UV_FS_STAT,
+  UV_FS_LSTAT,
+  UV_FS_FSTAT,
+  UV_FS_FTRUNCATE,
+  UV_FS_UTIME,
+  UV_FS_FUTIME,
+  UV_FS_ACCESS,
+  UV_FS_CHMOD,
+  UV_FS_FCHMOD,
+  UV_FS_FSYNC,
+  UV_FS_FDATASYNC,
+  UV_FS_UNLINK,
+  UV_FS_RMDIR,
+  UV_FS_MKDIR,
+  UV_FS_MKDTEMP,
+  UV_FS_RENAME,
+  UV_FS_SCANDIR,
+  UV_FS_LINK,
+  UV_FS_SYMLINK,
+  UV_FS_READLINK,
+  UV_FS_CHOWN,
+  UV_FS_FCHOWN,
+  UV_FS_REALPATH,
+  UV_FS_COPYFILE,
+  UV_FS_LCHOWN,
+  UV_FS_OPENDIR,
+  UV_FS_READDIR,
+  UV_FS_CLOSEDIR,
+  UV_FS_STATFS,
+  UV_FS_MKSTEMP,
+  UV_FS_LUTIME
+} uv_fs_type;
+
+struct uv_dir_s {
+  uv_dirent_t* dirents;
+  size_t nentries;
+  void* reserved[4];
+  UV_DIR_PRIVATE_FIELDS
+};
+
+/* uv_fs_t is a subclass of uv_req_t. */
+struct uv_fs_s {
+  UV_REQ_FIELDS
+  uv_fs_type fs_type;
+  uv_loop_t* loop;
+  uv_fs_cb cb;
+  ssize_t result;
+  void* ptr;
+  const char* path;
+  uv_stat_t statbuf;  /* Stores the result of uv_fs_stat() and uv_fs_fstat(). */
+  UV_FS_PRIVATE_FIELDS
+};
+
+UV_EXTERN uv_fs_type uv_fs_get_type(const uv_fs_t*);
+UV_EXTERN ssize_t uv_fs_get_result(const uv_fs_t*);
+UV_EXTERN int uv_fs_get_system_error(const uv_fs_t*);
+UV_EXTERN void* uv_fs_get_ptr(const uv_fs_t*);
+UV_EXTERN const char* uv_fs_get_path(const uv_fs_t*);
+UV_EXTERN uv_stat_t* uv_fs_get_statbuf(uv_fs_t*);
+
+UV_EXTERN void uv_fs_req_cleanup(uv_fs_t* req);
+UV_EXTERN int uv_fs_close(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          uv_file file,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_open(uv_loop_t* loop,
+                         uv_fs_t* req,
+                         const char* path,
+                         int flags,
+                         int mode,
+                         uv_fs_cb cb);
+UV_EXTERN int uv_fs_read(uv_loop_t* loop,
+                         uv_fs_t* req,
+                         uv_file file,
+                         const uv_buf_t bufs[],
+                         unsigned int nbufs,
+                         int64_t offset,
+                         uv_fs_cb cb);
+UV_EXTERN int uv_fs_unlink(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_write(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          uv_file file,
+                          const uv_buf_t bufs[],
+                          unsigned int nbufs,
+                          int64_t offset,
+                          uv_fs_cb cb);
+/*
+ * This flag can be used with uv_fs_copyfile() to return an error if the
+ * destination already exists.
+ */
+#define UV_FS_COPYFILE_EXCL   0x0001
+
+/*
+ * This flag can be used with uv_fs_copyfile() to attempt to create a reflink.
+ * If copy-on-write is not supported, a fallback copy mechanism is used.
+ */
+#define UV_FS_COPYFILE_FICLONE 0x0002
+
+/*
+ * This flag can be used with uv_fs_copyfile() to attempt to create a reflink.
+ * If copy-on-write is not supported, an error is returned.
+ */
+#define UV_FS_COPYFILE_FICLONE_FORCE 0x0004
+
+UV_EXTERN int uv_fs_copyfile(uv_loop_t* loop,
+                             uv_fs_t* req,
+                             const char* path,
+                             const char* new_path,
+                             int flags,
+                             uv_fs_cb cb);
+UV_EXTERN int uv_fs_mkdir(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          int mode,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* tpl,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_mkstemp(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* tpl,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_rmdir(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_scandir(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* path,
+                            int flags,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_scandir_next(uv_fs_t* req,
+                                 uv_dirent_t* ent);
+UV_EXTERN int uv_fs_opendir(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* path,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_readdir(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            uv_dir_t* dir,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_closedir(uv_loop_t* loop,
+                             uv_fs_t* req,
+                             uv_dir_t* dir,
+                             uv_fs_cb cb);
+UV_EXTERN int uv_fs_stat(uv_loop_t* loop,
+                         uv_fs_t* req,
+                         const char* path,
+                         uv_fs_cb cb);
+UV_EXTERN int uv_fs_fstat(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          uv_file file,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_rename(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           const char* new_path,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_fsync(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          uv_file file,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_fdatasync(uv_loop_t* loop,
+                              uv_fs_t* req,
+                              uv_file file,
+                              uv_fs_cb cb);
+UV_EXTERN int uv_fs_ftruncate(uv_loop_t* loop,
+                              uv_fs_t* req,
+                              uv_file file,
+                              int64_t offset,
+                              uv_fs_cb cb);
+UV_EXTERN int uv_fs_sendfile(uv_loop_t* loop,
+                             uv_fs_t* req,
+                             uv_file out_fd,
+                             uv_file in_fd,
+                             int64_t in_offset,
+                             size_t length,
+                             uv_fs_cb cb);
+UV_EXTERN int uv_fs_access(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           int mode,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_chmod(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          int mode,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_utime(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          double atime,
+                          double mtime,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_futime(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           uv_file file,
+                           double atime,
+                           double mtime,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_lutime(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           double atime,
+                           double mtime,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_lstat(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_link(uv_loop_t* loop,
+                         uv_fs_t* req,
+                         const char* path,
+                         const char* new_path,
+                         uv_fs_cb cb);
+
+/*
+ * This flag can be used with uv_fs_symlink() on Windows to specify whether
+ * path argument points to a directory.
+ */
+#define UV_FS_SYMLINK_DIR          0x0001
+
+/*
+ * This flag can be used with uv_fs_symlink() on Windows to specify whether
+ * the symlink is to be created using junction points.
+ */
+#define UV_FS_SYMLINK_JUNCTION     0x0002
+
+UV_EXTERN int uv_fs_symlink(uv_loop_t* loop,
+                            uv_fs_t* req,
+                            const char* path,
+                            const char* new_path,
+                            int flags,
+                            uv_fs_cb cb);
+UV_EXTERN int uv_fs_readlink(uv_loop_t* loop,
+                             uv_fs_t* req,
+                             const char* path,
+                             uv_fs_cb cb);
+UV_EXTERN int uv_fs_realpath(uv_loop_t* loop,
+                             uv_fs_t* req,
+                             const char* path,
+                             uv_fs_cb cb);
+UV_EXTERN int uv_fs_fchmod(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           uv_file file,
+                           int mode,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_chown(uv_loop_t* loop,
+                          uv_fs_t* req,
+                          const char* path,
+                          uv_uid_t uid,
+                          uv_gid_t gid,
+                          uv_fs_cb cb);
+UV_EXTERN int uv_fs_fchown(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           uv_file file,
+                           uv_uid_t uid,
+                           uv_gid_t gid,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_lchown(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           uv_uid_t uid,
+                           uv_gid_t gid,
+                           uv_fs_cb cb);
+UV_EXTERN int uv_fs_statfs(uv_loop_t* loop,
+                           uv_fs_t* req,
+                           const char* path,
+                           uv_fs_cb cb);
+
+
+enum uv_fs_event {
+  UV_RENAME = 1,
+  UV_CHANGE = 2
+};
+
+
+struct uv_fs_event_s {
+  UV_HANDLE_FIELDS
+  /* private */
+  char* path;
+  UV_FS_EVENT_PRIVATE_FIELDS
+};
+
+
+/*
+ * uv_fs_stat() based polling file watcher.
+ */
+struct uv_fs_poll_s {
+  UV_HANDLE_FIELDS
+  /* Private, don't touch. */
+  void* poll_ctx;
+};
+
+UV_EXTERN int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle);
+UV_EXTERN int uv_fs_poll_start(uv_fs_poll_t* handle,
+                               uv_fs_poll_cb poll_cb,
+                               const char* path,
+                               unsigned int interval);
+UV_EXTERN int uv_fs_poll_stop(uv_fs_poll_t* handle);
+UV_EXTERN int uv_fs_poll_getpath(uv_fs_poll_t* handle,
+                                 char* buffer,
+                                 size_t* size);
+
+
+struct uv_signal_s {
+  UV_HANDLE_FIELDS
+  uv_signal_cb signal_cb;
+  int signum;
+  UV_SIGNAL_PRIVATE_FIELDS
+};
+
+UV_EXTERN int uv_signal_init(uv_loop_t* loop, uv_signal_t* handle);
+UV_EXTERN int uv_signal_start(uv_signal_t* handle,
+                              uv_signal_cb signal_cb,
+                              int signum);
+UV_EXTERN int uv_signal_start_oneshot(uv_signal_t* handle,
+                                      uv_signal_cb signal_cb,
+                                      int signum);
+UV_EXTERN int uv_signal_stop(uv_signal_t* handle);
+
+UV_EXTERN void uv_loadavg(double avg[3]);
+
+
+/*
+ * Flags to be passed to uv_fs_event_start().
+ */
+enum uv_fs_event_flags {
+  /*
+   * By default, if the fs event watcher is given a directory name, we will
+   * watch for all events in that directory. This flags overrides this behavior
+   * and makes fs_event report only changes to the directory entry itself. This
+   * flag does not affect individual files watched.
+   * This flag is currently not implemented yet on any backend.
+   */
+  UV_FS_EVENT_WATCH_ENTRY = 1,
+
+  /*
+   * By default uv_fs_event will try to use a kernel interface such as inotify
+   * or kqueue to detect events. This may not work on remote filesystems such
+   * as NFS mounts. This flag makes fs_event fall back to calling stat() on a
+   * regular interval.
+   * This flag is currently not implemented yet on any backend.
+   */
+  UV_FS_EVENT_STAT = 2,
+
+  /*
+   * By default, event watcher, when watching directory, is not registering
+   * (is ignoring) changes in it's subdirectories.
+   * This flag will override this behaviour on platforms that support it.
+   */
+  UV_FS_EVENT_RECURSIVE = 4
+};
+
+
+UV_EXTERN int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle);
+UV_EXTERN int uv_fs_event_start(uv_fs_event_t* handle,
+                                uv_fs_event_cb cb,
+                                const char* path,
+                                unsigned int flags);
+UV_EXTERN int uv_fs_event_stop(uv_fs_event_t* handle);
+UV_EXTERN int uv_fs_event_getpath(uv_fs_event_t* handle,
+                                  char* buffer,
+                                  size_t* size);
+
+UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr);
+UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr);
+
+UV_EXTERN int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size);
+UV_EXTERN int uv_ip6_name(const struct sockaddr_in6* src, char* dst, size_t size);
+UV_EXTERN int uv_ip_name(const struct sockaddr* src, char* dst, size_t size);
+
+UV_EXTERN int uv_inet_ntop(int af, const void* src, char* dst, size_t size);
+UV_EXTERN int uv_inet_pton(int af, const char* src, void* dst);
+
+
+struct uv_random_s {
+  UV_REQ_FIELDS
+  /* read-only */
+  uv_loop_t* loop;
+  /* private */
+  int status;
+  void* buf;
+  size_t buflen;
+  uv_random_cb cb;
+  struct uv__work work_req;
+};
+
+UV_EXTERN int uv_random(uv_loop_t* loop,
+                        uv_random_t* req,
+                        void *buf,
+                        size_t buflen,
+                        unsigned flags,  /* For future extension; must be 0. */
+                        uv_random_cb cb);
+
+#if defined(IF_NAMESIZE)
+# define UV_IF_NAMESIZE (IF_NAMESIZE + 1)
+#elif defined(IFNAMSIZ)
+# define UV_IF_NAMESIZE (IFNAMSIZ + 1)
+#else
+# define UV_IF_NAMESIZE (16 + 1)
+#endif
+
+UV_EXTERN int uv_if_indextoname(unsigned int ifindex,
+                                char* buffer,
+                                size_t* size);
+UV_EXTERN int uv_if_indextoiid(unsigned int ifindex,
+                               char* buffer,
+                               size_t* size);
+
+UV_EXTERN int uv_exepath(char* buffer, size_t* size);
+
+UV_EXTERN int uv_cwd(char* buffer, size_t* size);
+
+UV_EXTERN int uv_chdir(const char* dir);
+
+UV_EXTERN uint64_t uv_get_free_memory(void);
+UV_EXTERN uint64_t uv_get_total_memory(void);
+UV_EXTERN uint64_t uv_get_constrained_memory(void);
+UV_EXTERN uint64_t uv_get_available_memory(void);
+
+UV_EXTERN int uv_clock_gettime(uv_clock_id clock_id, uv_timespec64_t* ts);
+UV_EXTERN uint64_t uv_hrtime(void);
+UV_EXTERN void uv_sleep(unsigned int msec);
+
+UV_EXTERN void uv_disable_stdio_inheritance(void);
+
+UV_EXTERN int uv_dlopen(const char* filename, uv_lib_t* lib);
+UV_EXTERN void uv_dlclose(uv_lib_t* lib);
+UV_EXTERN int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr);
+UV_EXTERN const char* uv_dlerror(const uv_lib_t* lib);
+
+UV_EXTERN int uv_mutex_init(uv_mutex_t* handle);
+UV_EXTERN int uv_mutex_init_recursive(uv_mutex_t* handle);
+UV_EXTERN void uv_mutex_destroy(uv_mutex_t* handle);
+UV_EXTERN void uv_mutex_lock(uv_mutex_t* handle);
+UV_EXTERN int uv_mutex_trylock(uv_mutex_t* handle);
+UV_EXTERN void uv_mutex_unlock(uv_mutex_t* handle);
+
+UV_EXTERN int uv_rwlock_init(uv_rwlock_t* rwlock);
+UV_EXTERN void uv_rwlock_destroy(uv_rwlock_t* rwlock);
+UV_EXTERN void uv_rwlock_rdlock(uv_rwlock_t* rwlock);
+UV_EXTERN int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock);
+UV_EXTERN void uv_rwlock_rdunlock(uv_rwlock_t* rwlock);
+UV_EXTERN void uv_rwlock_wrlock(uv_rwlock_t* rwlock);
+UV_EXTERN int uv_rwlock_trywrlock(uv_rwlock_t* rwlock);
+UV_EXTERN void uv_rwlock_wrunlock(uv_rwlock_t* rwlock);
+
+UV_EXTERN int uv_sem_init(uv_sem_t* sem, unsigned int value);
+UV_EXTERN void uv_sem_destroy(uv_sem_t* sem);
+UV_EXTERN void uv_sem_post(uv_sem_t* sem);
+UV_EXTERN void uv_sem_wait(uv_sem_t* sem);
+UV_EXTERN int uv_sem_trywait(uv_sem_t* sem);
+
+UV_EXTERN int uv_cond_init(uv_cond_t* cond);
+UV_EXTERN void uv_cond_destroy(uv_cond_t* cond);
+UV_EXTERN void uv_cond_signal(uv_cond_t* cond);
+UV_EXTERN void uv_cond_broadcast(uv_cond_t* cond);
+
+UV_EXTERN int uv_barrier_init(uv_barrier_t* barrier, unsigned int count);
+UV_EXTERN void uv_barrier_destroy(uv_barrier_t* barrier);
+UV_EXTERN int uv_barrier_wait(uv_barrier_t* barrier);
+
+UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex);
+UV_EXTERN int uv_cond_timedwait(uv_cond_t* cond,
+                                uv_mutex_t* mutex,
+                                uint64_t timeout);
+
+UV_EXTERN void uv_once(uv_once_t* guard, void (*callback)(void));
+
+UV_EXTERN int uv_key_create(uv_key_t* key);
+UV_EXTERN void uv_key_delete(uv_key_t* key);
+UV_EXTERN void* uv_key_get(uv_key_t* key);
+UV_EXTERN void uv_key_set(uv_key_t* key, void* value);
+
+UV_EXTERN int uv_gettimeofday(uv_timeval64_t* tv);
+
+typedef void (*uv_thread_cb)(void* arg);
+
+UV_EXTERN int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg);
+
+typedef enum {
+  UV_THREAD_NO_FLAGS = 0x00,
+  UV_THREAD_HAS_STACK_SIZE = 0x01
+} uv_thread_create_flags;
+
+struct uv_thread_options_s {
+  unsigned int flags;
+  size_t stack_size;
+  /* More fields may be added at any time. */
+};
+
+typedef struct uv_thread_options_s uv_thread_options_t;
+
+UV_EXTERN int uv_thread_create_ex(uv_thread_t* tid,
+                                  const uv_thread_options_t* params,
+                                  uv_thread_cb entry,
+                                  void* arg);
+UV_EXTERN int uv_thread_setaffinity(uv_thread_t* tid,
+                                    char* cpumask,
+                                    char* oldmask,
+                                    size_t mask_size);
+UV_EXTERN int uv_thread_getaffinity(uv_thread_t* tid,
+                                    char* cpumask,
+                                    size_t mask_size);
+UV_EXTERN int uv_thread_getcpu(void);
+UV_EXTERN uv_thread_t uv_thread_self(void);
+UV_EXTERN int uv_thread_join(uv_thread_t *tid);
+UV_EXTERN int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2);
+
+/* The presence of these unions force similar struct layout. */
+#define XX(_, name) uv_ ## name ## _t name;
+union uv_any_handle {
+  UV_HANDLE_TYPE_MAP(XX)
+};
+
+union uv_any_req {
+  UV_REQ_TYPE_MAP(XX)
+};
+#undef XX
+
+
+struct uv_loop_s {
+  /* User data - use this for whatever. */
+  void* data;
+  /* Loop reference counting. */
+  unsigned int active_handles;
+  struct uv__queue handle_queue;
+  union {
+    void* unused;
+    unsigned int count;
+  } active_reqs;
+  /* Internal storage for future extensions. */
+  void* internal_fields;
+  /* Internal flag to signal loop stop. */
+  unsigned int stop_flag;
+  UV_LOOP_PRIVATE_FIELDS
+};
+
+UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
+UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
+
+/* Unicode utilities needed for dealing with Windows. */
+UV_EXTERN size_t uv_utf16_length_as_wtf8(const uint16_t* utf16,
+                                         ssize_t utf16_len);
+UV_EXTERN int uv_utf16_to_wtf8(const uint16_t* utf16,
+                               ssize_t utf16_len,
+                               char** wtf8_ptr,
+                               size_t* wtf8_len_ptr);
+UV_EXTERN ssize_t uv_wtf8_length_as_utf16(const char* wtf8);
+UV_EXTERN void uv_wtf8_to_utf16(const char* wtf8,
+                                uint16_t* utf16,
+                                size_t utf16_len);
+
+/* Don't export the private CPP symbols. */
+#undef UV_HANDLE_TYPE_PRIVATE
+#undef UV_REQ_TYPE_PRIVATE
+#undef UV_REQ_PRIVATE_FIELDS
+#undef UV_STREAM_PRIVATE_FIELDS
+#undef UV_TCP_PRIVATE_FIELDS
+#undef UV_PREPARE_PRIVATE_FIELDS
+#undef UV_CHECK_PRIVATE_FIELDS
+#undef UV_IDLE_PRIVATE_FIELDS
+#undef UV_ASYNC_PRIVATE_FIELDS
+#undef UV_TIMER_PRIVATE_FIELDS
+#undef UV_GETADDRINFO_PRIVATE_FIELDS
+#undef UV_GETNAMEINFO_PRIVATE_FIELDS
+#undef UV_FS_REQ_PRIVATE_FIELDS
+#undef UV_WORK_PRIVATE_FIELDS
+#undef UV_FS_EVENT_PRIVATE_FIELDS
+#undef UV_SIGNAL_PRIVATE_FIELDS
+#undef UV_LOOP_PRIVATE_FIELDS
+#undef UV_LOOP_PRIVATE_PLATFORM_FIELDS
+#undef UV__ERR
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* UV_H */

--- a/prepocess/src/uv/errno.h
+++ b/prepocess/src/uv/errno.h
@@ -1,0 +1,477 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef UV_ERRNO_H_
+#define UV_ERRNO_H_
+
+#include <errno.h>
+#if EDOM > 0
+# define UV__ERR(x) (-(x))
+#else
+# define UV__ERR(x) (x)
+#endif
+
+#define UV__EOF     (-4095)
+#define UV__UNKNOWN (-4094)
+
+#define UV__EAI_ADDRFAMILY  (-3000)
+#define UV__EAI_AGAIN       (-3001)
+#define UV__EAI_BADFLAGS    (-3002)
+#define UV__EAI_CANCELED    (-3003)
+#define UV__EAI_FAIL        (-3004)
+#define UV__EAI_FAMILY      (-3005)
+#define UV__EAI_MEMORY      (-3006)
+#define UV__EAI_NODATA      (-3007)
+#define UV__EAI_NONAME      (-3008)
+#define UV__EAI_OVERFLOW    (-3009)
+#define UV__EAI_SERVICE     (-3010)
+#define UV__EAI_SOCKTYPE    (-3011)
+#define UV__EAI_BADHINTS    (-3013)
+#define UV__EAI_PROTOCOL    (-3014)
+
+/* Only map to the system errno on non-Windows platforms. It's apparently
+ * a fairly common practice for Windows programmers to redefine errno codes.
+ */
+#if defined(E2BIG) && !defined(_WIN32)
+# define UV__E2BIG UV__ERR(E2BIG)
+#else
+# define UV__E2BIG (-4093)
+#endif
+
+#if defined(EACCES) && !defined(_WIN32)
+# define UV__EACCES UV__ERR(EACCES)
+#else
+# define UV__EACCES (-4092)
+#endif
+
+#if defined(EADDRINUSE) && !defined(_WIN32)
+# define UV__EADDRINUSE UV__ERR(EADDRINUSE)
+#else
+# define UV__EADDRINUSE (-4091)
+#endif
+
+#if defined(EADDRNOTAVAIL) && !defined(_WIN32)
+# define UV__EADDRNOTAVAIL UV__ERR(EADDRNOTAVAIL)
+#else
+# define UV__EADDRNOTAVAIL (-4090)
+#endif
+
+#if defined(EAFNOSUPPORT) && !defined(_WIN32)
+# define UV__EAFNOSUPPORT UV__ERR(EAFNOSUPPORT)
+#else
+# define UV__EAFNOSUPPORT (-4089)
+#endif
+
+#if defined(EAGAIN) && !defined(_WIN32)
+# define UV__EAGAIN UV__ERR(EAGAIN)
+#else
+# define UV__EAGAIN (-4088)
+#endif
+
+#if defined(EALREADY) && !defined(_WIN32)
+# define UV__EALREADY UV__ERR(EALREADY)
+#else
+# define UV__EALREADY (-4084)
+#endif
+
+#if defined(EBADF) && !defined(_WIN32)
+# define UV__EBADF UV__ERR(EBADF)
+#else
+# define UV__EBADF (-4083)
+#endif
+
+#if defined(EBUSY) && !defined(_WIN32)
+# define UV__EBUSY UV__ERR(EBUSY)
+#else
+# define UV__EBUSY (-4082)
+#endif
+
+#if defined(ECANCELED) && !defined(_WIN32)
+# define UV__ECANCELED UV__ERR(ECANCELED)
+#else
+# define UV__ECANCELED (-4081)
+#endif
+
+#if defined(ECHARSET) && !defined(_WIN32)
+# define UV__ECHARSET UV__ERR(ECHARSET)
+#else
+# define UV__ECHARSET (-4080)
+#endif
+
+#if defined(ECONNABORTED) && !defined(_WIN32)
+# define UV__ECONNABORTED UV__ERR(ECONNABORTED)
+#else
+# define UV__ECONNABORTED (-4079)
+#endif
+
+#if defined(ECONNREFUSED) && !defined(_WIN32)
+# define UV__ECONNREFUSED UV__ERR(ECONNREFUSED)
+#else
+# define UV__ECONNREFUSED (-4078)
+#endif
+
+#if defined(ECONNRESET) && !defined(_WIN32)
+# define UV__ECONNRESET UV__ERR(ECONNRESET)
+#else
+# define UV__ECONNRESET (-4077)
+#endif
+
+#if defined(EDESTADDRREQ) && !defined(_WIN32)
+# define UV__EDESTADDRREQ UV__ERR(EDESTADDRREQ)
+#else
+# define UV__EDESTADDRREQ (-4076)
+#endif
+
+#if defined(EEXIST) && !defined(_WIN32)
+# define UV__EEXIST UV__ERR(EEXIST)
+#else
+# define UV__EEXIST (-4075)
+#endif
+
+#if defined(EFAULT) && !defined(_WIN32)
+# define UV__EFAULT UV__ERR(EFAULT)
+#else
+# define UV__EFAULT (-4074)
+#endif
+
+#if defined(EHOSTUNREACH) && !defined(_WIN32)
+# define UV__EHOSTUNREACH UV__ERR(EHOSTUNREACH)
+#else
+# define UV__EHOSTUNREACH (-4073)
+#endif
+
+#if defined(EINTR) && !defined(_WIN32)
+# define UV__EINTR UV__ERR(EINTR)
+#else
+# define UV__EINTR (-4072)
+#endif
+
+#if defined(EINVAL) && !defined(_WIN32)
+# define UV__EINVAL UV__ERR(EINVAL)
+#else
+# define UV__EINVAL (-4071)
+#endif
+
+#if defined(EIO) && !defined(_WIN32)
+# define UV__EIO UV__ERR(EIO)
+#else
+# define UV__EIO (-4070)
+#endif
+
+#if defined(EISCONN) && !defined(_WIN32)
+# define UV__EISCONN UV__ERR(EISCONN)
+#else
+# define UV__EISCONN (-4069)
+#endif
+
+#if defined(EISDIR) && !defined(_WIN32)
+# define UV__EISDIR UV__ERR(EISDIR)
+#else
+# define UV__EISDIR (-4068)
+#endif
+
+#if defined(ELOOP) && !defined(_WIN32)
+# define UV__ELOOP UV__ERR(ELOOP)
+#else
+# define UV__ELOOP (-4067)
+#endif
+
+#if defined(EMFILE) && !defined(_WIN32)
+# define UV__EMFILE UV__ERR(EMFILE)
+#else
+# define UV__EMFILE (-4066)
+#endif
+
+#if defined(EMSGSIZE) && !defined(_WIN32)
+# define UV__EMSGSIZE UV__ERR(EMSGSIZE)
+#else
+# define UV__EMSGSIZE (-4065)
+#endif
+
+#if defined(ENAMETOOLONG) && !defined(_WIN32)
+# define UV__ENAMETOOLONG UV__ERR(ENAMETOOLONG)
+#else
+# define UV__ENAMETOOLONG (-4064)
+#endif
+
+#if defined(ENETDOWN) && !defined(_WIN32)
+# define UV__ENETDOWN UV__ERR(ENETDOWN)
+#else
+# define UV__ENETDOWN (-4063)
+#endif
+
+#if defined(ENETUNREACH) && !defined(_WIN32)
+# define UV__ENETUNREACH UV__ERR(ENETUNREACH)
+#else
+# define UV__ENETUNREACH (-4062)
+#endif
+
+#if defined(ENFILE) && !defined(_WIN32)
+# define UV__ENFILE UV__ERR(ENFILE)
+#else
+# define UV__ENFILE (-4061)
+#endif
+
+#if defined(ENOBUFS) && !defined(_WIN32)
+# define UV__ENOBUFS UV__ERR(ENOBUFS)
+#else
+# define UV__ENOBUFS (-4060)
+#endif
+
+#if defined(ENODEV) && !defined(_WIN32)
+# define UV__ENODEV UV__ERR(ENODEV)
+#else
+# define UV__ENODEV (-4059)
+#endif
+
+#if defined(ENOENT) && !defined(_WIN32)
+# define UV__ENOENT UV__ERR(ENOENT)
+#else
+# define UV__ENOENT (-4058)
+#endif
+
+#if defined(ENOMEM) && !defined(_WIN32)
+# define UV__ENOMEM UV__ERR(ENOMEM)
+#else
+# define UV__ENOMEM (-4057)
+#endif
+
+#if defined(ENONET) && !defined(_WIN32)
+# define UV__ENONET UV__ERR(ENONET)
+#else
+# define UV__ENONET (-4056)
+#endif
+
+#if defined(ENOSPC) && !defined(_WIN32)
+# define UV__ENOSPC UV__ERR(ENOSPC)
+#else
+# define UV__ENOSPC (-4055)
+#endif
+
+#if defined(ENOSYS) && !defined(_WIN32)
+# define UV__ENOSYS UV__ERR(ENOSYS)
+#else
+# define UV__ENOSYS (-4054)
+#endif
+
+#if defined(ENOTCONN) && !defined(_WIN32)
+# define UV__ENOTCONN UV__ERR(ENOTCONN)
+#else
+# define UV__ENOTCONN (-4053)
+#endif
+
+#if defined(ENOTDIR) && !defined(_WIN32)
+# define UV__ENOTDIR UV__ERR(ENOTDIR)
+#else
+# define UV__ENOTDIR (-4052)
+#endif
+
+#if defined(ENOTEMPTY) && !defined(_WIN32)
+# define UV__ENOTEMPTY UV__ERR(ENOTEMPTY)
+#else
+# define UV__ENOTEMPTY (-4051)
+#endif
+
+#if defined(ENOTSOCK) && !defined(_WIN32)
+# define UV__ENOTSOCK UV__ERR(ENOTSOCK)
+#else
+# define UV__ENOTSOCK (-4050)
+#endif
+
+#if defined(ENOTSUP) && !defined(_WIN32)
+# define UV__ENOTSUP UV__ERR(ENOTSUP)
+#else
+# define UV__ENOTSUP (-4049)
+#endif
+
+#if defined(EPERM) && !defined(_WIN32)
+# define UV__EPERM UV__ERR(EPERM)
+#else
+# define UV__EPERM (-4048)
+#endif
+
+#if defined(EPIPE) && !defined(_WIN32)
+# define UV__EPIPE UV__ERR(EPIPE)
+#else
+# define UV__EPIPE (-4047)
+#endif
+
+#if defined(EPROTO) && !defined(_WIN32)
+# define UV__EPROTO UV__ERR(EPROTO)
+#else
+# define UV__EPROTO (-4046)
+#endif
+
+#if defined(EPROTONOSUPPORT) && !defined(_WIN32)
+# define UV__EPROTONOSUPPORT UV__ERR(EPROTONOSUPPORT)
+#else
+# define UV__EPROTONOSUPPORT (-4045)
+#endif
+
+#if defined(EPROTOTYPE) && !defined(_WIN32)
+# define UV__EPROTOTYPE UV__ERR(EPROTOTYPE)
+#else
+# define UV__EPROTOTYPE (-4044)
+#endif
+
+#if defined(EROFS) && !defined(_WIN32)
+# define UV__EROFS UV__ERR(EROFS)
+#else
+# define UV__EROFS (-4043)
+#endif
+
+#if defined(ESHUTDOWN) && !defined(_WIN32)
+# define UV__ESHUTDOWN UV__ERR(ESHUTDOWN)
+#else
+# define UV__ESHUTDOWN (-4042)
+#endif
+
+#if defined(ESPIPE) && !defined(_WIN32)
+# define UV__ESPIPE UV__ERR(ESPIPE)
+#else
+# define UV__ESPIPE (-4041)
+#endif
+
+#if defined(ESRCH) && !defined(_WIN32)
+# define UV__ESRCH UV__ERR(ESRCH)
+#else
+# define UV__ESRCH (-4040)
+#endif
+
+#if defined(ETIMEDOUT) && !defined(_WIN32)
+# define UV__ETIMEDOUT UV__ERR(ETIMEDOUT)
+#else
+# define UV__ETIMEDOUT (-4039)
+#endif
+
+#if defined(ETXTBSY) && !defined(_WIN32)
+# define UV__ETXTBSY UV__ERR(ETXTBSY)
+#else
+# define UV__ETXTBSY (-4038)
+#endif
+
+#if defined(EXDEV) && !defined(_WIN32)
+# define UV__EXDEV UV__ERR(EXDEV)
+#else
+# define UV__EXDEV (-4037)
+#endif
+
+#if defined(EFBIG) && !defined(_WIN32)
+# define UV__EFBIG UV__ERR(EFBIG)
+#else
+# define UV__EFBIG (-4036)
+#endif
+
+#if defined(ENOPROTOOPT) && !defined(_WIN32)
+# define UV__ENOPROTOOPT UV__ERR(ENOPROTOOPT)
+#else
+# define UV__ENOPROTOOPT (-4035)
+#endif
+
+#if defined(ERANGE) && !defined(_WIN32)
+# define UV__ERANGE UV__ERR(ERANGE)
+#else
+# define UV__ERANGE (-4034)
+#endif
+
+#if defined(ENXIO) && !defined(_WIN32)
+# define UV__ENXIO UV__ERR(ENXIO)
+#else
+# define UV__ENXIO (-4033)
+#endif
+
+#if defined(EMLINK) && !defined(_WIN32)
+# define UV__EMLINK UV__ERR(EMLINK)
+#else
+# define UV__EMLINK (-4032)
+#endif
+
+/* EHOSTDOWN is not visible on BSD-like systems when _POSIX_C_SOURCE is
+ * defined. Fortunately, its value is always 64 so it's possible albeit
+ * icky to hard-code it.
+ */
+#if defined(EHOSTDOWN) && !defined(_WIN32)
+# define UV__EHOSTDOWN UV__ERR(EHOSTDOWN)
+#elif defined(__APPLE__) || \
+      defined(__DragonFly__) || \
+      defined(__FreeBSD__) || \
+      defined(__NetBSD__) || \
+      defined(__OpenBSD__)
+# define UV__EHOSTDOWN (-64)
+#else
+# define UV__EHOSTDOWN (-4031)
+#endif
+
+#if defined(EREMOTEIO) && !defined(_WIN32)
+# define UV__EREMOTEIO UV__ERR(EREMOTEIO)
+#else
+# define UV__EREMOTEIO (-4030)
+#endif
+
+#if defined(ENOTTY) && !defined(_WIN32)
+# define UV__ENOTTY UV__ERR(ENOTTY)
+#else
+# define UV__ENOTTY (-4029)
+#endif
+
+#if defined(EFTYPE) && !defined(_WIN32)
+# define UV__EFTYPE UV__ERR(EFTYPE)
+#else
+# define UV__EFTYPE (-4028)
+#endif
+
+#if defined(EILSEQ) && !defined(_WIN32)
+# define UV__EILSEQ UV__ERR(EILSEQ)
+#else
+# define UV__EILSEQ (-4027)
+#endif
+
+#if defined(EOVERFLOW) && !defined(_WIN32)
+# define UV__EOVERFLOW UV__ERR(EOVERFLOW)
+#else
+# define UV__EOVERFLOW (-4026)
+#endif
+
+#if defined(ESOCKTNOSUPPORT) && !defined(_WIN32)
+# define UV__ESOCKTNOSUPPORT UV__ERR(ESOCKTNOSUPPORT)
+#else
+# define UV__ESOCKTNOSUPPORT (-4025)
+#endif
+
+/* FreeBSD defines ENODATA in /usr/include/c++/v1/errno.h which is only visible
+ * if C++ is being used. Define it directly to avoid problems when integrating
+ * libuv in a C++ project.
+ */
+#if defined(ENODATA) && !defined(_WIN32)
+# define UV__ENODATA UV__ERR(ENODATA)
+#elif defined(__FreeBSD__)
+# define UV__ENODATA (-9919)
+#else
+# define UV__ENODATA (-4024)
+#endif
+
+#if defined(EUNATCH) && !defined(_WIN32)
+# define UV__EUNATCH UV__ERR(EUNATCH)
+#else
+# define UV__EUNATCH (-4023)
+#endif
+
+#endif /* UV_ERRNO_H_ */

--- a/prepocess/src/uv/linux.h
+++ b/prepocess/src/uv/linux.h
@@ -1,0 +1,34 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef UV_LINUX_H
+#define UV_LINUX_H
+
+#define UV_PLATFORM_LOOP_FIELDS                                               \
+  uv__io_t inotify_read_watcher;                                              \
+  void* inotify_watchers;                                                     \
+  int inotify_fd;                                                             \
+
+#define UV_PLATFORM_FS_EVENT_FIELDS                                           \
+  struct uv__queue watchers;                                                  \
+  int wd;                                                                     \
+
+#endif /* UV_LINUX_H */

--- a/prepocess/src/uv/threadpool.h
+++ b/prepocess/src/uv/threadpool.h
@@ -1,0 +1,37 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/*
+ * This file is private to libuv. It provides common functionality to both
+ * Windows and Unix backends.
+ */
+
+#ifndef UV_THREADPOOL_H_
+#define UV_THREADPOOL_H_
+
+struct uv__work {
+  void (*work)(struct uv__work *w);
+  void (*done)(struct uv__work *w, int status);
+  struct uv_loop_s* loop;
+  struct uv__queue wq;
+};
+
+#endif /* UV_THREADPOOL_H_ */

--- a/prepocess/src/uv/unix.h
+++ b/prepocess/src/uv/unix.h
@@ -1,0 +1,509 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef UV_UNIX_H
+#define UV_UNIX_H
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <dirent.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>  /* MAXHOSTNAMELEN on Solaris */
+
+#include <termios.h>
+#include <pwd.h>
+
+#if !defined(__MVS__)
+#include <semaphore.h>
+#include <sys/param.h> /* MAXHOSTNAMELEN on Linux and the BSDs */
+#endif
+#include <pthread.h>
+#include <signal.h>
+
+#include "uv/threadpool.h"
+
+#if defined(__linux__)
+# include "uv/linux.h"
+#elif defined (__MVS__)
+# include "uv/os390.h"
+#elif defined(__PASE__)  /* __PASE__ and _AIX are both defined on IBM i */
+# include "uv/posix.h"  /* IBM i needs uv/posix.h, not uv/aix.h */
+#elif defined(_AIX)
+# include "uv/aix.h"
+#elif defined(__sun)
+# include "uv/sunos.h"
+#elif defined(__APPLE__)
+# include "uv/darwin.h"
+#elif defined(__DragonFly__)       || \
+      defined(__FreeBSD__)         || \
+      defined(__OpenBSD__)         || \
+      defined(__NetBSD__)
+# include "uv/bsd.h"
+#elif defined(__CYGWIN__) || \
+      defined(__MSYS__)   || \
+      defined(__HAIKU__)  || \
+      defined(__QNX__)    || \
+      defined(__GNU__)
+# include "uv/posix.h"
+#endif
+
+#ifndef NI_MAXHOST
+# define NI_MAXHOST 1025
+#endif
+
+#ifndef NI_MAXSERV
+# define NI_MAXSERV 32
+#endif
+
+#ifndef UV_IO_PRIVATE_PLATFORM_FIELDS
+# define UV_IO_PRIVATE_PLATFORM_FIELDS /* empty */
+#endif
+
+struct uv__io_s;
+struct uv_loop_s;
+
+typedef void (*uv__io_cb)(struct uv_loop_s* loop,
+                          struct uv__io_s* w,
+                          unsigned int events);
+typedef struct uv__io_s uv__io_t;
+
+struct uv__io_s {
+  uv__io_cb cb;
+  struct uv__queue pending_queue;
+  struct uv__queue watcher_queue;
+  unsigned int pevents; /* Pending event mask i.e. mask at next tick. */
+  unsigned int events;  /* Current event mask. */
+  int fd;
+  UV_IO_PRIVATE_PLATFORM_FIELDS
+};
+
+#ifndef UV_PLATFORM_SEM_T
+# define UV_PLATFORM_SEM_T sem_t
+#endif
+
+#ifndef UV_PLATFORM_LOOP_FIELDS
+# define UV_PLATFORM_LOOP_FIELDS /* empty */
+#endif
+
+#ifndef UV_PLATFORM_FS_EVENT_FIELDS
+# define UV_PLATFORM_FS_EVENT_FIELDS /* empty */
+#endif
+
+#ifndef UV_STREAM_PRIVATE_PLATFORM_FIELDS
+# define UV_STREAM_PRIVATE_PLATFORM_FIELDS /* empty */
+#endif
+
+/* Note: May be cast to struct iovec. See writev(2). */
+typedef struct uv_buf_t {
+  char* base;
+  size_t len;
+} uv_buf_t;
+
+typedef int uv_file;
+typedef int uv_os_sock_t;
+typedef int uv_os_fd_t;
+typedef pid_t uv_pid_t;
+
+#define UV_ONCE_INIT PTHREAD_ONCE_INIT
+
+typedef pthread_once_t uv_once_t;
+typedef pthread_t uv_thread_t;
+typedef pthread_mutex_t uv_mutex_t;
+typedef pthread_rwlock_t uv_rwlock_t;
+typedef UV_PLATFORM_SEM_T uv_sem_t;
+typedef pthread_cond_t uv_cond_t;
+typedef pthread_key_t uv_key_t;
+
+/* Note: guard clauses should match uv_barrier_init's in src/unix/thread.c. */
+#if defined(_AIX) || \
+    defined(__OpenBSD__) || \
+    !defined(PTHREAD_BARRIER_SERIAL_THREAD)
+/* TODO(bnoordhuis) Merge into uv_barrier_t in v2. */
+struct _uv_barrier {
+  uv_mutex_t mutex;
+  uv_cond_t cond;
+  unsigned threshold;
+  unsigned in;
+  unsigned out;
+};
+
+typedef struct {
+  struct _uv_barrier* b;
+# if defined(PTHREAD_BARRIER_SERIAL_THREAD)
+  /* TODO(bnoordhuis) Remove padding in v2. */
+  char pad[sizeof(pthread_barrier_t) - sizeof(struct _uv_barrier*)];
+# endif
+} uv_barrier_t;
+#else
+typedef pthread_barrier_t uv_barrier_t;
+#endif
+
+/* Platform-specific definitions for uv_spawn support. */
+typedef gid_t uv_gid_t;
+typedef uid_t uv_uid_t;
+
+typedef struct dirent uv__dirent_t;
+
+#define UV_DIR_PRIVATE_FIELDS \
+  DIR* dir;
+
+#if defined(DT_UNKNOWN)
+# define HAVE_DIRENT_TYPES
+# if defined(DT_REG)
+#  define UV__DT_FILE DT_REG
+# else
+#  define UV__DT_FILE -1
+# endif
+# if defined(DT_DIR)
+#  define UV__DT_DIR DT_DIR
+# else
+#  define UV__DT_DIR -2
+# endif
+# if defined(DT_LNK)
+#  define UV__DT_LINK DT_LNK
+# else
+#  define UV__DT_LINK -3
+# endif
+# if defined(DT_FIFO)
+#  define UV__DT_FIFO DT_FIFO
+# else
+#  define UV__DT_FIFO -4
+# endif
+# if defined(DT_SOCK)
+#  define UV__DT_SOCKET DT_SOCK
+# else
+#  define UV__DT_SOCKET -5
+# endif
+# if defined(DT_CHR)
+#  define UV__DT_CHAR DT_CHR
+# else
+#  define UV__DT_CHAR -6
+# endif
+# if defined(DT_BLK)
+#  define UV__DT_BLOCK DT_BLK
+# else
+#  define UV__DT_BLOCK -7
+# endif
+#endif
+
+/* Platform-specific definitions for uv_dlopen support. */
+#define UV_DYNAMIC /* empty */
+
+typedef struct {
+  void* handle;
+  char* errmsg;
+} uv_lib_t;
+
+#define UV_LOOP_PRIVATE_FIELDS                                                \
+  unsigned long flags;                                                        \
+  int backend_fd;                                                             \
+  struct uv__queue pending_queue;                                             \
+  struct uv__queue watcher_queue;                                             \
+  uv__io_t** watchers;                                                        \
+  unsigned int nwatchers;                                                     \
+  unsigned int nfds;                                                          \
+  struct uv__queue wq;                                                        \
+  uv_mutex_t wq_mutex;                                                        \
+  uv_async_t wq_async;                                                        \
+  uv_rwlock_t cloexec_lock;                                                   \
+  uv_handle_t* closing_handles;                                               \
+  struct uv__queue process_handles;                                           \
+  struct uv__queue prepare_handles;                                           \
+  struct uv__queue check_handles;                                             \
+  struct uv__queue idle_handles;                                              \
+  struct uv__queue async_handles;                                             \
+  void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
+  uv__io_t async_io_watcher;                                                  \
+  int async_wfd;                                                              \
+  struct {                                                                    \
+    void* min;                                                                \
+    unsigned int nelts;                                                       \
+  } timer_heap;                                                               \
+  uint64_t timer_counter;                                                     \
+  uint64_t time;                                                              \
+  int signal_pipefd[2];                                                       \
+  uv__io_t signal_io_watcher;                                                 \
+  uv_signal_t child_watcher;                                                  \
+  int emfile_fd;                                                              \
+  UV_PLATFORM_LOOP_FIELDS                                                     \
+
+#define UV_REQ_TYPE_PRIVATE /* empty */
+
+#define UV_REQ_PRIVATE_FIELDS  /* empty */
+
+#define UV_PRIVATE_REQ_TYPES /* empty */
+
+#define UV_WRITE_PRIVATE_FIELDS                                               \
+  struct uv__queue queue;                                                     \
+  unsigned int write_index;                                                   \
+  uv_buf_t* bufs;                                                             \
+  unsigned int nbufs;                                                         \
+  int error;                                                                  \
+  uv_buf_t bufsml[4];                                                         \
+
+#define UV_CONNECT_PRIVATE_FIELDS                                             \
+  struct uv__queue queue;                                                     \
+
+#define UV_SHUTDOWN_PRIVATE_FIELDS /* empty */
+
+#define UV_UDP_SEND_PRIVATE_FIELDS                                            \
+  struct uv__queue queue;                                                     \
+  struct sockaddr_storage addr;                                               \
+  unsigned int nbufs;                                                         \
+  uv_buf_t* bufs;                                                             \
+  ssize_t status;                                                             \
+  uv_udp_send_cb send_cb;                                                     \
+  uv_buf_t bufsml[4];                                                         \
+
+#define UV_HANDLE_PRIVATE_FIELDS                                              \
+  uv_handle_t* next_closing;                                                  \
+  unsigned int flags;                                                         \
+
+#define UV_STREAM_PRIVATE_FIELDS                                              \
+  uv_connect_t *connect_req;                                                  \
+  uv_shutdown_t *shutdown_req;                                                \
+  uv__io_t io_watcher;                                                        \
+  struct uv__queue write_queue;                                               \
+  struct uv__queue write_completed_queue;                                     \
+  uv_connection_cb connection_cb;                                             \
+  int delayed_error;                                                          \
+  int accepted_fd;                                                            \
+  void* queued_fds;                                                           \
+  UV_STREAM_PRIVATE_PLATFORM_FIELDS                                           \
+
+#define UV_TCP_PRIVATE_FIELDS /* empty */
+
+#define UV_UDP_PRIVATE_FIELDS                                                 \
+  uv_alloc_cb alloc_cb;                                                       \
+  uv_udp_recv_cb recv_cb;                                                     \
+  uv__io_t io_watcher;                                                        \
+  struct uv__queue write_queue;                                               \
+  struct uv__queue write_completed_queue;                                     \
+
+#define UV_PIPE_PRIVATE_FIELDS                                                \
+  const char* pipe_fname; /* NULL or strdup'ed */
+
+#define UV_POLL_PRIVATE_FIELDS                                                \
+  uv__io_t io_watcher;
+
+#define UV_PREPARE_PRIVATE_FIELDS                                             \
+  uv_prepare_cb prepare_cb;                                                   \
+  struct uv__queue queue;                                                     \
+
+#define UV_CHECK_PRIVATE_FIELDS                                               \
+  uv_check_cb check_cb;                                                       \
+  struct uv__queue queue;                                                     \
+
+#define UV_IDLE_PRIVATE_FIELDS                                                \
+  uv_idle_cb idle_cb;                                                         \
+  struct uv__queue queue;                                                     \
+
+#define UV_ASYNC_PRIVATE_FIELDS                                               \
+  uv_async_cb async_cb;                                                       \
+  struct uv__queue queue;                                                     \
+  int pending;                                                                \
+
+#define UV_TIMER_PRIVATE_FIELDS                                               \
+  uv_timer_cb timer_cb;                                                       \
+  union {                                                                     \
+    void* heap[3];                                                            \
+    struct uv__queue queue;                                                   \
+  } node;                                                                     \
+  uint64_t timeout;                                                           \
+  uint64_t repeat;                                                            \
+  uint64_t start_id;
+
+#define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
+  struct uv__work work_req;                                                   \
+  uv_getaddrinfo_cb cb;                                                       \
+  struct addrinfo* hints;                                                     \
+  char* hostname;                                                             \
+  char* service;                                                              \
+  struct addrinfo* addrinfo;                                                  \
+  int retcode;
+
+#define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
+  struct uv__work work_req;                                                   \
+  uv_getnameinfo_cb getnameinfo_cb;                                           \
+  struct sockaddr_storage storage;                                            \
+  int flags;                                                                  \
+  char host[NI_MAXHOST];                                                      \
+  char service[NI_MAXSERV];                                                   \
+  int retcode;
+
+#define UV_PROCESS_PRIVATE_FIELDS                                             \
+  struct uv__queue queue;                                                     \
+  int status;                                                                 \
+
+#define UV_FS_PRIVATE_FIELDS                                                  \
+  const char *new_path;                                                       \
+  uv_file file;                                                               \
+  int flags;                                                                  \
+  mode_t mode;                                                                \
+  unsigned int nbufs;                                                         \
+  uv_buf_t* bufs;                                                             \
+  off_t off;                                                                  \
+  uv_uid_t uid;                                                               \
+  uv_gid_t gid;                                                               \
+  double atime;                                                               \
+  double mtime;                                                               \
+  struct uv__work work_req;                                                   \
+  uv_buf_t bufsml[4];                                                         \
+
+#define UV_WORK_PRIVATE_FIELDS                                                \
+  struct uv__work work_req;
+
+#define UV_TTY_PRIVATE_FIELDS                                                 \
+  struct termios orig_termios;                                                \
+  int mode;
+
+#define UV_SIGNAL_PRIVATE_FIELDS                                              \
+  /* RB_ENTRY(uv_signal_s) tree_entry; */                                     \
+  struct {                                                                    \
+    struct uv_signal_s* rbe_left;                                             \
+    struct uv_signal_s* rbe_right;                                            \
+    struct uv_signal_s* rbe_parent;                                           \
+    int rbe_color;                                                            \
+  } tree_entry;                                                               \
+  /* Use two counters here so we don have to fiddle with atomics. */          \
+  unsigned int caught_signals;                                                \
+  unsigned int dispatched_signals;
+
+#define UV_FS_EVENT_PRIVATE_FIELDS                                            \
+  uv_fs_event_cb cb;                                                          \
+  UV_PLATFORM_FS_EVENT_FIELDS                                                 \
+
+/* fs open() flags supported on this platform: */
+#if defined(O_APPEND)
+# define UV_FS_O_APPEND       O_APPEND
+#else
+# define UV_FS_O_APPEND       0
+#endif
+#if defined(O_CREAT)
+# define UV_FS_O_CREAT        O_CREAT
+#else
+# define UV_FS_O_CREAT        0
+#endif
+
+#if defined(__linux__) && defined(__arm__)
+# define UV_FS_O_DIRECT       0x10000
+#elif defined(__linux__) && defined(__m68k__)
+# define UV_FS_O_DIRECT       0x10000
+#elif defined(__linux__) && defined(__mips__)
+# define UV_FS_O_DIRECT       0x08000
+#elif defined(__linux__) && defined(__powerpc__)
+# define UV_FS_O_DIRECT       0x20000
+#elif defined(__linux__) && defined(__s390x__)
+# define UV_FS_O_DIRECT       0x04000
+#elif defined(__linux__) && defined(__x86_64__)
+# define UV_FS_O_DIRECT       0x04000
+#elif defined(__linux__) && defined(__loongarch__)
+# define UV_FS_O_DIRECT       0x04000
+#elif defined(O_DIRECT)
+# define UV_FS_O_DIRECT       O_DIRECT
+#else
+# define UV_FS_O_DIRECT       0
+#endif
+
+#if defined(O_DIRECTORY)
+# define UV_FS_O_DIRECTORY    O_DIRECTORY
+#else
+# define UV_FS_O_DIRECTORY    0
+#endif
+#if defined(O_DSYNC)
+# define UV_FS_O_DSYNC        O_DSYNC
+#else
+# define UV_FS_O_DSYNC        0
+#endif
+#if defined(O_EXCL)
+# define UV_FS_O_EXCL         O_EXCL
+#else
+# define UV_FS_O_EXCL         0
+#endif
+#if defined(O_EXLOCK)
+# define UV_FS_O_EXLOCK       O_EXLOCK
+#else
+# define UV_FS_O_EXLOCK       0
+#endif
+#if defined(O_NOATIME)
+# define UV_FS_O_NOATIME      O_NOATIME
+#else
+# define UV_FS_O_NOATIME      0
+#endif
+#if defined(O_NOCTTY)
+# define UV_FS_O_NOCTTY       O_NOCTTY
+#else
+# define UV_FS_O_NOCTTY       0
+#endif
+#if defined(O_NOFOLLOW)
+# define UV_FS_O_NOFOLLOW     O_NOFOLLOW
+#else
+# define UV_FS_O_NOFOLLOW     0
+#endif
+#if defined(O_NONBLOCK)
+# define UV_FS_O_NONBLOCK     O_NONBLOCK
+#else
+# define UV_FS_O_NONBLOCK     0
+#endif
+#if defined(O_RDONLY)
+# define UV_FS_O_RDONLY       O_RDONLY
+#else
+# define UV_FS_O_RDONLY       0
+#endif
+#if defined(O_RDWR)
+# define UV_FS_O_RDWR         O_RDWR
+#else
+# define UV_FS_O_RDWR         0
+#endif
+#if defined(O_SYMLINK)
+# define UV_FS_O_SYMLINK      O_SYMLINK
+#else
+# define UV_FS_O_SYMLINK      0
+#endif
+#if defined(O_SYNC)
+# define UV_FS_O_SYNC         O_SYNC
+#else
+# define UV_FS_O_SYNC         0
+#endif
+#if defined(O_TRUNC)
+# define UV_FS_O_TRUNC        O_TRUNC
+#else
+# define UV_FS_O_TRUNC        0
+#endif
+#if defined(O_WRONLY)
+# define UV_FS_O_WRONLY       O_WRONLY
+#else
+# define UV_FS_O_WRONLY       0
+#endif
+
+/* fs open() flags supported on other platforms: */
+#define UV_FS_O_FILEMAP       0
+#define UV_FS_O_RANDOM        0
+#define UV_FS_O_SHORT_LIVED   0
+#define UV_FS_O_SEQUENTIAL    0
+#define UV_FS_O_TEMPORARY     0
+
+#endif /* UV_UNIX_H */

--- a/prepocess/src/uv/version.h
+++ b/prepocess/src/uv/version.h
@@ -1,0 +1,43 @@
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef UV_VERSION_H
+#define UV_VERSION_H
+
+ /*
+ * Versions with the same major number are ABI stable. API is allowed to
+ * evolve between minor releases, but only in a backwards compatible way.
+ * Make sure you update the -soname directives in configure.ac
+ * whenever you bump UV_VERSION_MAJOR or UV_VERSION_MINOR (but
+ * not UV_VERSION_PATCH.)
+ */
+
+#define UV_VERSION_MAJOR 1
+#define UV_VERSION_MINOR 49
+#define UV_VERSION_PATCH 2
+#define UV_VERSION_IS_RELEASE 1
+#define UV_VERSION_SUFFIX ""
+
+#define UV_VERSION_HEX  ((UV_VERSION_MAJOR << 16) | \
+                         (UV_VERSION_MINOR <<  8) | \
+                         (UV_VERSION_PATCH))
+
+#endif /* UV_VERSION_H */

--- a/prepocess/uv-normal/uv.odin
+++ b/prepocess/uv-normal/uv.odin
@@ -45,15 +45,6 @@ buf_t :: struct {
     len: u64,
 }
 alloc_cb :: #type proc "c" (handle: ^handle_t, suggested_size: u64, buf: ^buf_t)
-io_cb :: rawptr
-io_s :: struct {
-    cb: io_cb,
-    pending_queue: queue,
-    watcher_queue: queue,
-    pevents: u32,
-    events: u32,
-    fd: i32,
-}
 io_t :: io_s
 stream_s :: struct {
     data: rawptr,
@@ -727,6 +718,15 @@ barrier_t :: struct {
     b: ^_uv_barrier,
 }
 key_t :: posix.pthread_key_t
+io_s :: struct {
+    cb: io_cb,
+    pending_queue: queue,
+    watcher_queue: queue,
+    pevents: u32,
+    events: u32,
+    fd: i32,
+}
+io_cb :: #type proc "c" (loop: ^loop_s, w: ^io_s, events: u32)
 
 when #config(UV_STATIC, false) {
     foreign import uv_runic "system:libuv.a"

--- a/prepocess/uv-normal/uv.odin
+++ b/prepocess/uv-normal/uv.odin
@@ -1,1977 +1,1673 @@
 package uv
 
-EXTERN :: `__attribute__((visibility(\"default\")))`
+import "core:c/libc"
+import "core:sys/linux"
+import "core:sys/posix"
 
-uv__queue :: struct {
-	next: ^uv__queue,
-	prev: ^uv__queue,
-}
-uv_errno_t :: enum i32 {
-	E2BIG           = -4093,
-	EACCES          = -4092,
-	EADDRINUSE      = -4091,
-	EADDRNOTAVAIL   = -4090,
-	EAFNOSUPPORT    = -4089,
-	EAGAIN          = -4088,
-	EAI_ADDRFAMILY  = -3000,
-	EAI_AGAIN       = -3001,
-	EAI_BADFLAGS    = -3002,
-	EAI_BADHINTS    = -3013,
-	EAI_CANCELED    = -3003,
-	EAI_FAIL        = -3004,
-	EAI_FAMILY      = -3005,
-	EAI_MEMORY      = -3006,
-	EAI_NODATA      = -3007,
-	EAI_NONAME      = -3008,
-	EAI_OVERFLOW    = -3009,
-	EAI_PROTOCOL    = -3014,
-	EAI_SERVICE     = -3010,
-	EAI_SOCKTYPE    = -3011,
-	EALREADY        = -4084,
-	EBADF           = -4083,
-	EBUSY           = -4082,
-	ECANCELED       = -4081,
-	ECHARSET        = -4080,
-	ECONNABORTED    = -4079,
-	ECONNREFUSED    = -4078,
-	ECONNRESET      = -4077,
-	EDESTADDRREQ    = -4076,
-	EEXIST          = -4075,
-	EFAULT          = -4074,
-	EFBIG           = -4036,
-	EHOSTUNREACH    = -4073,
-	EINTR           = -4072,
-	EINVAL          = -4071,
-	EIO             = -4070,
-	EISCONN         = -4069,
-	EISDIR          = -4068,
-	ELOOP           = -4067,
-	EMFILE          = -4066,
-	EMSGSIZE        = -4065,
-	ENAMETOOLONG    = -4064,
-	ENETDOWN        = -4063,
-	ENETUNREACH     = -4062,
-	ENFILE          = -4061,
-	ENOBUFS         = -4060,
-	ENODEV          = -4059,
-	ENOENT          = -4058,
-	ENOMEM          = -4057,
-	ENONET          = -4056,
-	ENOPROTOOPT     = -4035,
-	ENOSPC          = -4055,
-	ENOSYS          = -4054,
-	ENOTCONN        = -4053,
-	ENOTDIR         = -4052,
-	ENOTEMPTY       = -4051,
-	ENOTSOCK        = -4050,
-	ENOTSUP         = -4049,
-	EOVERFLOW       = -4026,
-	EPERM           = -4048,
-	EPIPE           = -4047,
-	EPROTO          = -4046,
-	EPROTONOSUPPORT = -4045,
-	EPROTOTYPE      = -4044,
-	ERANGE          = -4034,
-	EROFS           = -4043,
-	ESHUTDOWN       = -4042,
-	ESPIPE          = -4041,
-	ESRCH           = -4040,
-	ETIMEDOUT       = -4039,
-	ETXTBSY         = -4038,
-	EXDEV           = -4037,
-	UNKNOWN         = -4094,
-	EOF             = -4095,
-	ENXIO           = -4033,
-	EMLINK          = -4032,
-	EHOSTDOWN       = -4031,
-	EREMOTEIO       = -4030,
-	ENOTTY          = -4029,
-	EFTYPE          = -4028,
-	EILSEQ          = -4027,
-	ESOCKTNOSUPPORT = -4025,
-	ENODATA         = -4024,
-	EUNATCH         = -4023,
-	ERRNO_MAX       = -4096,
-}
-uv_handle_type :: enum u32 {
-	UNKNOWN_HANDLE  = 0,
-	ASYNC           = 1,
-	CHECK           = 2,
-	FS_EVENT        = 3,
-	FS_POLL         = 4,
-	HANDLE          = 5,
-	IDLE            = 6,
-	NAMED_PIPE      = 7,
-	POLL            = 8,
-	PREPARE         = 9,
-	PROCESS         = 10,
-	STREAM          = 11,
-	TCP             = 12,
-	TIMER           = 13,
-	TTY             = 14,
-	UDP             = 15,
-	SIGNAL          = 16,
-	FILE            = 17,
-	HANDLE_TYPE_MAX = 18,
-}
-uv_req_type :: enum u32 {
-	UNKNOWN_REQ  = 0,
-	REQ          = 1,
-	CONNECT      = 2,
-	WRITE        = 3,
-	SHUTDOWN     = 4,
-	UDP_SEND     = 5,
-	FS           = 6,
-	WORK         = 7,
-	GETADDRINFO  = 8,
-	GETNAMEINFO  = 9,
-	RANDOM       = 10,
-	REQ_TYPE_MAX = 11,
-}
-uv_loop_t :: uv_loop_s
-u_union_anon_0 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_handle_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_0,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-}
-uv_handle_t :: uv_handle_s
-uv_dirent_type_t :: enum u32 {
-	DIRENT_UNKNOWN = 0,
-	DIRENT_FILE    = 1,
-	DIRENT_DIR     = 2,
-	DIRENT_LINK    = 3,
-	DIRENT_FIFO    = 4,
-	DIRENT_SOCKET  = 5,
-	DIRENT_CHAR    = 6,
-	DIRENT_BLOCK   = 7,
-}
-uv_dirent_s :: struct {
-	name: cstring,
-	type: uv_dirent_type_t,
-}
-uv_dirent_t :: uv_dirent_s
-uv_dir_s :: struct {
-	dirents:  [^]uv_dirent_t,
-	nentries: u64,
-	reserved: [4]rawptr,
-	dir:      ^i32,
-}
-uv_dir_t :: uv_dir_s
-uv_close_cb :: #type proc "c" (handle: ^uv_handle_t)
-u_union_anon_1 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_buf_t :: struct {
-	base: cstring,
-	len:  u64,
-}
-uv_alloc_cb :: #type proc "c" (handle: ^uv_handle_t, suggested_size: u64, buf: ^uv_buf_t)
-uv__io_cb :: ^^^rawptr
-uv__io_s :: struct {
-	cb:            uv__io_cb,
-	pending_queue: uv__queue,
-	watcher_queue: uv__queue,
-	pevents:       u32,
-	events:        u32,
-	fd:            i32,
-}
-uv__io_t :: uv__io_s
-uv_stream_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_1,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      i32,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-}
-uv_stream_t :: uv_stream_s
-u_union_anon_2 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_connect_t :: uv_connect_s
-uv_shutdown_t :: uv_shutdown_s
-uv_connection_cb :: #type proc "c" (server: ^uv_stream_t, status: i32)
-uv_tcp_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_2,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      i32,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-}
-uv_tcp_t :: uv_tcp_s
-u_union_anon_3 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_udp_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_3,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	send_queue_size:       u64,
-	send_queue_count:      u64,
-	alloc_cb:              uv_alloc_cb,
-	recv_cb:               uv_udp_recv_cb,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-}
-uv_udp_t :: uv_udp_s
-u_union_anon_5 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_pipe_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_5,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      i32,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-	ipc:                   i32,
-	pipe_fname:            cstring,
-}
-uv_pipe_t :: uv_pipe_s
-u_union_anon_4 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-termios :: ^^^rawptr
-uv_tty_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_4,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      i32,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-	orig_termios:          termios,
-	mode:                  i32,
-}
-uv_tty_t :: uv_tty_s
-u_union_anon_6 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_poll_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_6,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	poll_cb:      uv_poll_cb,
-	io_watcher:   uv__io_t,
-}
-uv_poll_t :: uv_poll_s
-u_union_anon_11 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-node_union_anon_12 :: struct #raw_union {
-	heap:  [3]rawptr,
-	queue: uv__queue,
-}
-uv_timer_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_11,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	timer_cb:     uv_timer_cb,
-	node:         node_union_anon_12,
-	timeout:      u64,
-	repeat:       u64,
-	start_id:     u64,
-}
-uv_timer_t :: uv_timer_s
-u_union_anon_7 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_prepare_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_7,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	prepare_cb:   uv_prepare_cb,
-	queue:        uv__queue,
-}
-uv_prepare_t :: uv_prepare_s
-u_union_anon_8 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_check_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_8,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	check_cb:     uv_check_cb,
-	queue:        uv__queue,
-}
-uv_check_t :: uv_check_s
-u_union_anon_9 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_idle_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_9,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	idle_cb:      uv_idle_cb,
-	queue:        uv__queue,
-}
-uv_idle_t :: uv_idle_s
-u_union_anon_10 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_async_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_10,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	async_cb:     uv_async_cb,
-	queue:        uv__queue,
-	pending:      i32,
-}
-uv_async_t :: uv_async_s
-u_union_anon_14 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_process_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_14,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	exit_cb:      uv_exit_cb,
-	pid:          i32,
-	queue:        uv__queue,
-	status:       i32,
-}
-uv_process_t :: uv_process_s
-u_union_anon_17 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_fs_event_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_17,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	path:         cstring,
-	cb:           uv_fs_event_cb,
-}
-uv_fs_event_t :: uv_fs_event_s
-u_union_anon_18 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_fs_poll_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_18,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	poll_ctx:     rawptr,
-}
-uv_fs_poll_t :: uv_fs_poll_s
-u_union_anon_19 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_signal_s :: struct {
-	data:               rawptr,
-	loop:               ^uv_loop_t,
-	type:               uv_handle_type,
-	close_cb:           uv_close_cb,
-	handle_queue:       uv__queue,
-	u:                  u_union_anon_19,
-	next_closing:       ^uv_handle_t,
-	flags:              u32,
-	signal_cb:          uv_signal_cb,
-	signum:             i32,
-	tree_entry:         tree_entry_struct_anon_20,
-	caught_signals:     u32,
-	dispatched_signals: u32,
-}
-uv_signal_t :: uv_signal_s
-uv_req_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-}
-uv_req_t :: uv_req_s
-uv__work :: ^^^rawptr
-addrinfo :: ^^^rawptr
-uv_getaddrinfo_s :: struct {
-	data:       rawptr,
-	type:       uv_req_type,
-	reserved:   [6]rawptr,
-	loop:       ^uv_loop_t,
-	work_req:   uv__work,
-	cb:         uv_getaddrinfo_cb,
-	hints:      [^]addrinfo,
-	hostname:   cstring,
-	service:    cstring,
-	addrinfo_m: ^addrinfo,
-	retcode:    i32,
-}
-uv_getaddrinfo_t :: uv_getaddrinfo_s
-sockaddr_storage :: ^^^rawptr
-uv_getnameinfo_s :: struct {
-	data:           rawptr,
-	type:           uv_req_type,
-	reserved:       [6]rawptr,
-	loop:           ^uv_loop_t,
-	work_req:       uv__work,
-	getnameinfo_cb: uv_getnameinfo_cb,
-	storage:        sockaddr_storage,
-	flags:          i32,
-	host:           [1025]i8,
-	service:        [32]i8,
-	retcode:        i32,
-}
-uv_getnameinfo_t :: uv_getnameinfo_s
-uv_shutdown_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	handle:   ^uv_stream_t,
-	cb:       uv_shutdown_cb,
-}
-uv_write_s :: struct {
-	data:        rawptr,
-	type:        uv_req_type,
-	reserved:    [6]rawptr,
-	cb:          uv_write_cb,
-	send_handle: ^uv_stream_t,
-	handle:      ^uv_stream_t,
-	queue:       uv__queue,
-	write_index: u32,
-	bufs:        [^]uv_buf_t,
-	nbufs:       u32,
-	error:       i32,
-	bufsml:      [4]uv_buf_t,
-}
-uv_write_t :: uv_write_s
-uv_connect_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	cb:       uv_connect_cb,
-	handle:   ^uv_stream_t,
-	queue:    uv__queue,
-}
-uv_udp_send_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	handle:   ^uv_udp_t,
-	cb:       uv_udp_send_cb,
-	queue:    uv__queue,
-	addr:     sockaddr_storage,
-	nbufs:    u32,
-	bufs:     [^]uv_buf_t,
-	status:   i32,
-	send_cb:  uv_udp_send_cb,
-	bufsml:   [4]uv_buf_t,
-}
-uv_udp_send_t :: uv_udp_send_s
-uv_fs_type :: enum i32 {
-	FS_UNKNOWN   = -1,
-	FS_CUSTOM    = 0,
-	FS_OPEN      = 1,
-	FS_CLOSE     = 2,
-	FS_READ      = 3,
-	FS_WRITE     = 4,
-	FS_SENDFILE  = 5,
-	FS_STAT      = 6,
-	FS_LSTAT     = 7,
-	FS_FSTAT     = 8,
-	FS_FTRUNCATE = 9,
-	FS_UTIME     = 10,
-	FS_FUTIME    = 11,
-	FS_ACCESS    = 12,
-	FS_CHMOD     = 13,
-	FS_FCHMOD    = 14,
-	FS_FSYNC     = 15,
-	FS_FDATASYNC = 16,
-	FS_UNLINK    = 17,
-	FS_RMDIR     = 18,
-	FS_MKDIR     = 19,
-	FS_MKDTEMP   = 20,
-	FS_RENAME    = 21,
-	FS_SCANDIR   = 22,
-	FS_LINK      = 23,
-	FS_SYMLINK   = 24,
-	FS_READLINK  = 25,
-	FS_CHOWN     = 26,
-	FS_FCHOWN    = 27,
-	FS_REALPATH  = 28,
-	FS_COPYFILE  = 29,
-	FS_LCHOWN    = 30,
-	FS_OPENDIR   = 31,
-	FS_READDIR   = 32,
-	FS_CLOSEDIR  = 33,
-	FS_STATFS    = 34,
-	FS_MKSTEMP   = 35,
-	FS_LUTIME    = 36,
-}
-uv_timespec_t :: struct {
-	tv_sec:  i64,
-	tv_nsec: i64,
-}
-uv_stat_t :: struct {
-	st_dev:      u64,
-	st_mode:     u64,
-	st_nlink:    u64,
-	st_uid:      u64,
-	st_gid:      u64,
-	st_rdev:     u64,
-	st_ino:      u64,
-	st_size:     u64,
-	st_blksize:  u64,
-	st_blocks:   u64,
-	st_flags:    u64,
-	st_gen:      u64,
-	st_atim:     uv_timespec_t,
-	st_mtim:     uv_timespec_t,
-	st_ctim:     uv_timespec_t,
-	st_birthtim: uv_timespec_t,
-}
-uv_file :: i32
-uv_uid_t :: i32
-uv_gid_t :: i32
-uv_fs_t :: uv_fs_s
-uv_work_s :: struct {
-	data:          rawptr,
-	type:          uv_req_type,
-	reserved:      [6]rawptr,
-	loop:          ^uv_loop_t,
-	work_cb:       uv_work_cb,
-	after_work_cb: uv_after_work_cb,
-	work_req:      uv__work,
-}
-uv_work_t :: uv_work_s
-uv_random_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	loop:     ^uv_loop_t,
-	status:   i32,
-	buf:      rawptr,
-	buflen:   u64,
-	cb:       uv_random_cb,
-	work_req: uv__work,
-}
-uv_random_t :: uv_random_s
-uv_env_item_s :: struct {
-	name:  cstring,
-	value: cstring,
-}
-uv_env_item_t :: uv_env_item_s
-uv_cpu_times_s :: struct {
-	user: u64,
-	nice: u64,
-	sys:  u64,
-	idle: u64,
-	irq:  u64,
-}
-uv_cpu_info_s :: struct {
-	model:     cstring,
-	speed:     i32,
-	cpu_times: uv_cpu_times_s,
-}
-uv_cpu_info_t :: uv_cpu_info_s
-sockaddr_in :: ^^^rawptr
-sockaddr_in6 :: ^^^rawptr
-address_union_anon_15 :: struct #raw_union {
-	address4: sockaddr_in,
-	address6: sockaddr_in6,
-}
-netmask_union_anon_16 :: struct #raw_union {
-	netmask4: sockaddr_in,
-	netmask6: sockaddr_in6,
-}
-uv_interface_address_s :: struct {
-	name:        cstring,
-	phys_addr:   [6]i8,
-	is_internal: i32,
-	address:     address_union_anon_15,
-	netmask:     netmask_union_anon_16,
-}
-uv_interface_address_t :: uv_interface_address_s
-uv_passwd_s :: struct {
-	username: cstring,
-	uid:      u64,
-	gid:      u64,
-	shell:    cstring,
-	homedir:  cstring,
-}
-uv_passwd_t :: uv_passwd_s
-uv_group_s :: struct {
-	groupname: cstring,
-	gid:       u64,
-	members:   [^]cstring,
-}
-uv_group_t :: uv_group_s
-uv_utsname_s :: struct {
-	sysname: [256]i8,
-	release: [256]i8,
-	version: [256]i8,
-	machine: [256]i8,
-}
-uv_utsname_t :: uv_utsname_s
-uv_statfs_s :: struct {
-	f_type:   u64,
-	f_bsize:  u64,
-	f_blocks: u64,
-	f_bfree:  u64,
-	f_bavail: u64,
-	f_files:  u64,
-	f_ffree:  u64,
-	f_spare:  [4]u64,
-}
-uv_statfs_t :: uv_statfs_s
-uv_metrics_s :: struct {
-	loop_count:     u64,
-	events:         u64,
-	events_waiting: u64,
-	reserved:       ^[13]^u64,
-}
-uv_metrics_t :: uv_metrics_s
-uv_loop_option :: enum u32 {
-	LOOP_BLOCK_SIGNAL        = 0,
-	METRICS_IDLE_TIME        = 1,
-	LOOP_USE_IO_URING_SQPOLL = 2,
-}
-uv_run_mode :: enum u32 {
-	RUN_DEFAULT = 0,
-	RUN_ONCE    = 1,
-	RUN_NOWAIT  = 2,
-}
-uv_malloc_func :: #type proc "c" (size: u64) -> rawptr
-uv_realloc_func :: #type proc "c" (ptr: rawptr, size: u64) -> rawptr
-uv_calloc_func :: #type proc "c" (count: u64, size: u64) -> rawptr
-uv_free_func :: #type proc "c" (ptr: rawptr)
-uv_write_cb :: #type proc "c" (req: ^uv_write_t, status: i32)
-uv_connect_cb :: #type proc "c" (req: ^uv_connect_t, status: i32)
-uv_shutdown_cb :: #type proc "c" (req: ^uv_shutdown_t, status: i32)
-uv_poll_cb :: #type proc "c" (handle: ^uv_poll_t, status: i32, events: i32)
-uv_timer_cb :: #type proc "c" (handle: ^uv_timer_t)
-uv_async_cb :: #type proc "c" (handle: ^uv_async_t)
-uv_prepare_cb :: #type proc "c" (handle: ^uv_prepare_t)
-uv_check_cb :: #type proc "c" (handle: ^uv_check_t)
-uv_idle_cb :: #type proc "c" (handle: ^uv_idle_t)
-uv_exit_cb :: #type proc "c" (param0: ^uv_process_t, exit_status: i64, term_signal: i32)
-uv_walk_cb :: #type proc "c" (handle: ^uv_handle_t, arg: rawptr)
-uv_fs_cb :: #type proc "c" (req: ^uv_fs_t)
-uv_work_cb :: #type proc "c" (req: ^uv_work_t)
-uv_after_work_cb :: #type proc "c" (req: ^uv_work_t, status: i32)
-uv_getaddrinfo_cb :: #type proc "c" (req: ^uv_getaddrinfo_t, status: i32, res: [^]addrinfo)
-uv_getnameinfo_cb :: #type proc "c" (
-	req: ^uv_getnameinfo_t,
-	status: i32,
-	hostname: cstring,
-	service: cstring,
-)
-uv_random_cb :: #type proc "c" (req: ^uv_random_t, status: i32, buf: rawptr, buflen: u64)
-uv_clock_id :: enum u32 {
-	CLOCK_MONOTONIC = 0,
-	CLOCK_REALTIME  = 1,
-}
-uv_timespec64_t :: struct {
-	tv_sec:  i64,
-	tv_nsec: i32,
-}
-uv_timeval_t :: struct {
-	tv_sec:  i64,
-	tv_usec: i64,
-}
-uv_timeval64_t :: struct {
-	tv_sec:  i64,
-	tv_usec: i32,
-}
-uv_fs_event_cb :: #type proc "c" (
-	handle: ^uv_fs_event_t,
-	filename: cstring,
-	events: i32,
-	status: i32,
-)
-uv_fs_poll_cb :: #type proc "c" (
-	handle: ^uv_fs_poll_t,
-	status: i32,
-	prev: ^uv_stat_t,
-	curr: ^uv_stat_t,
-)
-uv_signal_cb :: #type proc "c" (handle: ^uv_signal_t, signum: i32)
-uv_membership :: enum u32 {
-	LEAVE_GROUP = 0,
-	JOIN_GROUP  = 1,
-}
-uv_tcp_flags :: enum u32 {
-	TCP_IPV6ONLY  = 1,
-	TCP_REUSEPORT = 2,
-}
-uv_udp_flags :: enum u32 {
-	UDP_IPV6ONLY      = 1,
-	UDP_PARTIAL       = 2,
-	UDP_REUSEADDR     = 4,
-	UDP_MMSG_CHUNK    = 8,
-	UDP_MMSG_FREE     = 16,
-	UDP_LINUX_RECVERR = 32,
-	UDP_REUSEPORT     = 64,
-	UDP_RECVMMSG      = 256,
-}
-uv_udp_send_cb :: #type proc "c" (req: ^uv_udp_send_t, status: i32)
-sockaddr :: ^^^rawptr
-uv_tty_mode_t :: enum u32 {
-	TTY_MODE_NORMAL = 0,
-	TTY_MODE_RAW    = 1,
-	TTY_MODE_IO     = 2,
-}
-uv_tty_vtermstate_t :: enum u32 {
-	TTY_SUPPORTED   = 0,
-	TTY_UNSUPPORTED = 1,
-}
-uv_poll_event :: enum u32 {
-	READABLE    = 1,
-	WRITABLE    = 2,
-	DISCONNECT  = 4,
-	PRIORITIZED = 8,
-}
-uv_stdio_flags :: enum u32 {
-	IGNORE          = 0,
-	CREATE_PIPE     = 1,
-	INHERIT_FD      = 2,
-	INHERIT_STREAM  = 4,
-	READABLE_PIPE   = 16,
-	WRITABLE_PIPE   = 32,
-	NONBLOCK_PIPE   = 64,
-	OVERLAPPED_PIPE = 64,
-}
-data_union_anon_13 :: struct #raw_union {
-	stream: ^uv_stream_t,
-	fd:     i32,
-}
-uv_stdio_container_s :: struct {
-	flags: uv_stdio_flags,
-	data:  data_union_anon_13,
-}
-uv_stdio_container_t :: uv_stdio_container_s
-uv_process_options_s :: struct {
-	exit_cb:     uv_exit_cb,
-	file:        cstring,
-	args:        [^]cstring,
-	env:         ^cstring,
-	cwd:         cstring,
-	flags:       u32,
-	stdio_count: i32,
-	stdio:       ^uv_stdio_container_t,
-	uid:         uv_uid_t,
-	gid:         uv_gid_t,
-}
-uv_process_options_t :: uv_process_options_s
-uv_process_flags :: enum u32 {
-	PROCESS_SETUID                       = 1,
-	PROCESS_SETGID                       = 2,
-	PROCESS_WINDOWS_VERBATIM_ARGUMENTS   = 4,
-	PROCESS_DETACHED                     = 8,
-	PROCESS_WINDOWS_HIDE                 = 16,
-	PROCESS_WINDOWS_HIDE_CONSOLE         = 32,
-	PROCESS_WINDOWS_HIDE_GUI             = 64,
-	PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = 128,
-}
-uv_rusage_t :: struct {
-	ru_utime:    uv_timeval_t,
-	ru_stime:    uv_timeval_t,
-	ru_maxrss:   u64,
-	ru_ixrss:    u64,
-	ru_idrss:    u64,
-	ru_isrss:    u64,
-	ru_minflt:   u64,
-	ru_majflt:   u64,
-	ru_nswap:    u64,
-	ru_inblock:  u64,
-	ru_oublock:  u64,
-	ru_msgsnd:   u64,
-	ru_msgrcv:   u64,
-	ru_nsignals: u64,
-	ru_nvcsw:    u64,
-	ru_nivcsw:   u64,
-}
-uv_fs_event :: enum u32 {
-	RENAME = 1,
-	CHANGE = 2,
-}
-tree_entry_struct_anon_20 :: struct {
-	rbe_left:   ^uv_signal_s,
-	rbe_right:  ^uv_signal_s,
-	rbe_parent: ^uv_signal_s,
-	rbe_color:  i32,
-}
-uv_fs_event_flags :: enum u32 {
-	FS_EVENT_WATCH_ENTRY = 1,
-	FS_EVENT_STAT        = 2,
-	FS_EVENT_RECURSIVE   = 4,
-}
-callback_func_ptr_anon_21 :: #type proc "c" ()
-uv_thread_cb :: #type proc "c" (arg: rawptr)
-uv_thread_create_flags :: enum u32 {
-	THREAD_NO_FLAGS       = 0,
-	THREAD_HAS_STACK_SIZE = 1,
-}
-uv_thread_options_s :: struct {
-	flags:      u32,
-	stack_size: u64,
-}
-uv_thread_options_t :: uv_thread_options_s
-uv_any_handle :: struct #raw_union {
-	async:    uv_async_t,
-	check:    uv_check_t,
-	fs_event: uv_fs_event_t,
-	fs_poll:  uv_fs_poll_t,
-	handle:   uv_handle_t,
-	idle:     uv_idle_t,
-	pipe:     uv_pipe_t,
-	poll:     uv_poll_t,
-	prepare:  uv_prepare_t,
-	process:  uv_process_t,
-	stream:   uv_stream_t,
-	tcp:      uv_tcp_t,
-	timer:    uv_timer_t,
-	tty:      uv_tty_t,
-	udp:      uv_udp_t,
-	signal:   uv_signal_t,
-}
-uv_any_req :: struct #raw_union {
-	req:         uv_req_t,
-	connect:     uv_connect_t,
-	write:       uv_write_t,
-	shutdown:    uv_shutdown_t,
-	udp_send:    uv_udp_send_t,
-	fs:          uv_fs_t,
-	work:        uv_work_t,
-	getaddrinfo: uv_getaddrinfo_t,
-	getnameinfo: uv_getnameinfo_t,
-	random:      uv_random_t,
-}
-active_reqs_union_anon_22 :: struct #raw_union {
-	unused: rawptr,
-	count:  u32,
-}
+pthread_rwlock_t :: [56]i8
+queue :: struct {
+    next: ^queue,
+    prev: ^queue,
+}
+errno_t :: enum i32 {E2BIG = -4093, EACCES = -4092, EADDRINUSE = -4091, EADDRNOTAVAIL = -4090, EAFNOSUPPORT = -4089, EAGAIN = -4088, EAI_ADDRFAMILY = -3000, EAI_AGAIN = -3001, EAI_BADFLAGS = -3002, EAI_BADHINTS = -3013, EAI_CANCELED = -3003, EAI_FAIL = -3004, EAI_FAMILY = -3005, EAI_MEMORY = -3006, EAI_NODATA = -3007, EAI_NONAME = -3008, EAI_OVERFLOW = -3009, EAI_PROTOCOL = -3014, EAI_SERVICE = -3010, EAI_SOCKTYPE = -3011, EALREADY = -4084, EBADF = -4083, EBUSY = -4082, ECANCELED = -4081, ECHARSET = -4080, ECONNABORTED = -4079, ECONNREFUSED = -4078, ECONNRESET = -4077, EDESTADDRREQ = -4076, EEXIST = -4075, EFAULT = -4074, EFBIG = -4036, EHOSTUNREACH = -4073, EINTR = -4072, EINVAL = -4071, EIO = -4070, EISCONN = -4069, EISDIR = -4068, ELOOP = -4067, EMFILE = -4066, EMSGSIZE = -4065, ENAMETOOLONG = -4064, ENETDOWN = -4063, ENETUNREACH = -4062, ENFILE = -4061, ENOBUFS = -4060, ENODEV = -4059, ENOENT = -4058, ENOMEM = -4057, ENONET = -4056, ENOPROTOOPT = -4035, ENOSPC = -4055, ENOSYS = -4054, ENOTCONN = -4053, ENOTDIR = -4052, ENOTEMPTY = -4051, ENOTSOCK = -4050, ENOTSUP = -4049, EOVERFLOW = -4026, EPERM = -4048, EPIPE = -4047, EPROTO = -4046, EPROTONOSUPPORT = -4045, EPROTOTYPE = -4044, ERANGE = -4034, EROFS = -4043, ESHUTDOWN = -4042, ESPIPE = -4041, ESRCH = -4040, ETIMEDOUT = -4039, ETXTBSY = -4038, EXDEV = -4037, UNKNOWN = -4094, EOF = -4095, ENXIO = -4033, EMLINK = -4032, EHOSTDOWN = -4031, EREMOTEIO = -4030, ENOTTY = -4029, EFTYPE = -4028, EILSEQ = -4027, ESOCKTNOSUPPORT = -4025, ENODATA = -4024, EUNATCH = -4023, ERRNO_MAX = -4096, }
+handle_type :: enum u32 {UNKNOWN_HANDLE = 0, ASYNC = 1, CHECK = 2, FS_EVENT = 3, FS_POLL = 4, HANDLE = 5, IDLE = 6, NAMED_PIPE = 7, POLL = 8, PREPARE = 9, PROCESS = 10, STREAM = 11, TCP = 12, TIMER = 13, TTY = 14, UDP = 15, SIGNAL = 16, FILE = 17, HANDLE_TYPE_MAX = 18, }
+req_type :: enum u32 {UNKNOWN_REQ = 0, REQ = 1, CONNECT = 2, WRITE = 3, SHUTDOWN = 4, UDP_SEND = 5, FS = 6, WORK = 7, GETADDRINFO = 8, GETNAMEINFO = 9, RANDOM = 10, REQ_TYPE_MAX = 11, }
+loop_t :: loop_s
+u_union_anon_0 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+handle_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_0,
+    next_closing: ^handle_t,
+    flags: u32,
+}
+handle_t :: handle_s
+dirent_type_t :: enum u32 {DIRENT_UNKNOWN = 0, DIRENT_FILE = 1, DIRENT_DIR = 2, DIRENT_LINK = 3, DIRENT_FIFO = 4, DIRENT_SOCKET = 5, DIRENT_CHAR = 6, DIRENT_BLOCK = 7, }
+dirent_s :: struct {
+    name: cstring,
+    type: dirent_type_t,
+}
+dirent_t :: dirent_s
+dir_s :: struct {
+    dirents: [^]dirent_t,
+    nentries: u64,
+    reserved: [4]rawptr,
+    dir: ^posix.DIR,
+}
+dir_t :: dir_s
+close_cb :: #type proc "c" (handle: ^handle_t)
+u_union_anon_1 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+buf_t :: struct {
+    base: cstring,
+    len: u64,
+}
+alloc_cb :: #type proc "c" (handle: ^handle_t, suggested_size: u64, buf: ^buf_t)
+io_cb :: rawptr
+io_s :: struct {
+    cb: io_cb,
+    pending_queue: queue,
+    watcher_queue: queue,
+    pevents: u32,
+    events: u32,
+    fd: i32,
+}
+io_t :: io_s
+stream_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_1,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+}
+stream_t :: stream_s
+u_union_anon_2 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+read_cb :: #type proc "c" (stream: ^stream_t, nread: i64, buf: ^buf_t)
+connect_t :: connect_s
+shutdown_t :: shutdown_s
+connection_cb :: #type proc "c" (server: ^stream_t, status: i32)
+tcp_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_2,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+}
+tcp_t :: tcp_s
+u_union_anon_3 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+udp_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_3,
+    next_closing: ^handle_t,
+    flags: u32,
+    send_queue_size: u64,
+    send_queue_count: u64,
+    alloc_cb_m: alloc_cb,
+    recv_cb: udp_recv_cb,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+}
+udp_t :: udp_s
+u_union_anon_5 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+pipe_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_5,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+    ipc: i32,
+    pipe_fname: cstring,
+}
+pipe_t :: pipe_s
+u_union_anon_4 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+tty_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_4,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+    orig_termios: posix.termios,
+    mode: i32,
+}
+tty_t :: tty_s
+u_union_anon_6 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+poll_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_6,
+    next_closing: ^handle_t,
+    flags: u32,
+    poll_cb_m: poll_cb,
+    io_watcher: io_t,
+}
+poll_t :: poll_s
+u_union_anon_11 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+node_union_anon_12 :: struct #raw_union {heap: [3]rawptr, queue_m: queue, }
+timer_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_11,
+    next_closing: ^handle_t,
+    flags: u32,
+    timer_cb_m: timer_cb,
+    node: node_union_anon_12,
+    timeout: u64,
+    repeat: u64,
+    start_id: u64,
+}
+timer_t :: timer_s
+u_union_anon_7 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+prepare_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_7,
+    next_closing: ^handle_t,
+    flags: u32,
+    prepare_cb_m: prepare_cb,
+    queue_m: queue,
+}
+prepare_t :: prepare_s
+u_union_anon_8 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+check_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_8,
+    next_closing: ^handle_t,
+    flags: u32,
+    check_cb_m: check_cb,
+    queue_m: queue,
+}
+check_t :: check_s
+u_union_anon_9 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+idle_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_9,
+    next_closing: ^handle_t,
+    flags: u32,
+    idle_cb_m: idle_cb,
+    queue_m: queue,
+}
+idle_t :: idle_s
+u_union_anon_10 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+async_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_10,
+    next_closing: ^handle_t,
+    flags: u32,
+    async_cb_m: async_cb,
+    queue_m: queue,
+    pending: i32,
+}
+async_t :: async_s
+u_union_anon_14 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+process_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_14,
+    next_closing: ^handle_t,
+    flags: u32,
+    exit_cb_m: exit_cb,
+    pid: i32,
+    queue_m: queue,
+    status: i32,
+}
+process_t :: process_s
+u_union_anon_17 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+fs_event_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_17,
+    next_closing: ^handle_t,
+    flags: u32,
+    path: cstring,
+    cb: fs_event_cb,
+    watchers: queue,
+    wd: i32,
+}
+fs_event_t :: fs_event_s
+u_union_anon_18 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+fs_poll_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_18,
+    next_closing: ^handle_t,
+    flags: u32,
+    poll_ctx: rawptr,
+}
+fs_poll_t :: fs_poll_s
+u_union_anon_19 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+signal_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_19,
+    next_closing: ^handle_t,
+    flags: u32,
+    signal_cb_m: signal_cb,
+    signum: i32,
+    tree_entry: tree_entry_struct_anon_20,
+    caught_signals: u32,
+    dispatched_signals: u32,
+}
+signal_t :: signal_s
+req_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+}
+req_t :: req_s
+active_reqs_union_anon_22 :: struct #raw_union {unused: rawptr, count: u32, }
+mutex_t :: posix.pthread_mutex_t
+rwlock_t :: pthread_rwlock_t
 async_unused_func_ptr_anon_23 :: #type proc "c" ()
 timer_heap_struct_anon_24 :: struct {
-	min:   rawptr,
-	nelts: u32,
+    min: rawptr,
+    nelts: u32,
 }
-uv_mutex_t :: i32
-uv_rwlock_t :: i32
-uv_loop_s :: struct {
-	data:              rawptr,
-	active_handles:    u32,
-	handle_queue:      uv__queue,
-	active_reqs:       active_reqs_union_anon_22,
-	internal_fields:   rawptr,
-	stop_flag:         u32,
-	flags:             u64,
-	backend_fd:        i32,
-	pending_queue:     uv__queue,
-	watcher_queue:     uv__queue,
-	watchers:          ^[^]uv__io_t,
-	nwatchers:         u32,
-	nfds:              u32,
-	wq:                uv__queue,
-	wq_mutex:          uv_mutex_t,
-	wq_async:          uv_async_t,
-	cloexec_lock:      uv_rwlock_t,
-	closing_handles:   [^]uv_handle_t,
-	process_handles:   uv__queue,
-	prepare_handles:   uv__queue,
-	check_handles:     uv__queue,
-	idle_handles:      uv__queue,
-	async_handles:     uv__queue,
-	async_unused:      async_unused_func_ptr_anon_23,
-	async_io_watcher:  uv__io_t,
-	async_wfd:         i32,
-	timer_heap:        timer_heap_struct_anon_24,
-	timer_counter:     u64,
-	time:              u64,
-	signal_pipefd:     [2]i32,
-	signal_io_watcher: uv__io_t,
-	child_watcher:     uv_signal_t,
-	emfile_fd:         i32,
+loop_s :: struct {
+    data: rawptr,
+    active_handles: u32,
+    handle_queue: queue,
+    active_reqs: active_reqs_union_anon_22,
+    internal_fields: rawptr,
+    stop_flag: u32,
+    flags: u64,
+    backend_fd: i32,
+    pending_queue: queue,
+    watcher_queue: queue,
+    watchers: ^[^]io_t,
+    nwatchers: u32,
+    nfds: u32,
+    wq: queue,
+    wq_mutex: mutex_t,
+    wq_async: async_t,
+    cloexec_lock: rwlock_t,
+    closing_handles: [^]handle_t,
+    process_handles: queue,
+    prepare_handles: queue,
+    check_handles: queue,
+    idle_handles: queue,
+    async_handles: queue,
+    async_unused: async_unused_func_ptr_anon_23,
+    async_io_watcher: io_t,
+    async_wfd: i32,
+    timer_heap: timer_heap_struct_anon_24,
+    timer_counter: u64,
+    time: u64,
+    signal_pipefd: [2]i32,
+    signal_io_watcher: io_t,
+    child_watcher: signal_t,
+    emfile_fd: i32,
+    inotify_read_watcher: io_t,
+    inotify_watchers: rawptr,
+    inotify_fd: i32,
 }
-_IO_marker :: ^^^rawptr
-_IO_lock_t :: ^^^rawptr
-_IO_codecvt :: ^^^rawptr
-_IO_wide_data :: ^^^rawptr
-FILE :: _IO_FILE
-uv_os_fd_t :: i32
-uv_os_sock_t :: i32
-uv_pid_t :: i32
-uv_thread_t :: i32
-uv_lib_t :: struct {
-	handle: rawptr,
-	errmsg: cstring,
+work :: struct {
+    work_m: work_func_ptr_anon_25,
+    done: done_func_ptr_anon_26,
+    loop: ^loop_s,
+    wq: queue,
 }
-uv_sem_t :: i32
-uv_cond_t :: i32
+getaddrinfo_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_req: work,
+    cb: getaddrinfo_cb,
+    hints: [^]posix.addrinfo,
+    hostname: cstring,
+    service: cstring,
+    addrinfo: ^posix.addrinfo,
+    retcode: i32,
+}
+getaddrinfo_t :: getaddrinfo_s
+getnameinfo_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_req: work,
+    getnameinfo_cb_m: getnameinfo_cb,
+    storage: posix.sockaddr_storage,
+    flags: i32,
+    host: [1025]i8,
+    service: [32]i8,
+    retcode: i32,
+}
+getnameinfo_t :: getnameinfo_s
+shutdown_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    handle: ^stream_t,
+    cb: shutdown_cb,
+}
+write_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    cb: write_cb,
+    send_handle: ^stream_t,
+    handle: ^stream_t,
+    queue_m: queue,
+    write_index: u32,
+    bufs: [^]buf_t,
+    nbufs: u32,
+    error: i32,
+    bufsml: [4]buf_t,
+}
+write_t :: write_s
+connect_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    cb: connect_cb,
+    handle: ^stream_t,
+    queue_m: queue,
+}
+udp_send_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    handle: ^udp_t,
+    cb: udp_send_cb,
+    queue_m: queue,
+    addr: posix.sockaddr_storage,
+    nbufs: u32,
+    bufs: [^]buf_t,
+    status: i64,
+    send_cb: udp_send_cb,
+    bufsml: [4]buf_t,
+}
+udp_send_t :: udp_send_s
+fs_type :: enum i32 {FS_UNKNOWN = -1, FS_CUSTOM = 0, FS_OPEN = 1, FS_CLOSE = 2, FS_READ = 3, FS_WRITE = 4, FS_SENDFILE = 5, FS_STAT = 6, FS_LSTAT = 7, FS_FSTAT = 8, FS_FTRUNCATE = 9, FS_UTIME = 10, FS_FUTIME = 11, FS_ACCESS = 12, FS_CHMOD = 13, FS_FCHMOD = 14, FS_FSYNC = 15, FS_FDATASYNC = 16, FS_UNLINK = 17, FS_RMDIR = 18, FS_MKDIR = 19, FS_MKDTEMP = 20, FS_RENAME = 21, FS_SCANDIR = 22, FS_LINK = 23, FS_SYMLINK = 24, FS_READLINK = 25, FS_CHOWN = 26, FS_FCHOWN = 27, FS_REALPATH = 28, FS_COPYFILE = 29, FS_LCHOWN = 30, FS_OPENDIR = 31, FS_READDIR = 32, FS_CLOSEDIR = 33, FS_STATFS = 34, FS_MKSTEMP = 35, FS_LUTIME = 36, }
+timespec_t :: struct {
+    tv_sec: i64,
+    tv_nsec: i64,
+}
+stat_t :: struct {
+    st_dev: u64,
+    st_mode: u64,
+    st_nlink: u64,
+    st_uid: u64,
+    st_gid: u64,
+    st_rdev: u64,
+    st_ino: u64,
+    st_size: u64,
+    st_blksize: u64,
+    st_blocks: u64,
+    st_flags: u64,
+    st_gen: u64,
+    st_atim: timespec_t,
+    st_mtim: timespec_t,
+    st_ctim: timespec_t,
+    st_birthtim: timespec_t,
+}
+file :: i32
+uid_t :: linux.Uid
+gid_t :: linux.Gid
+fs_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    fs_type_m: fs_type,
+    loop: ^loop_t,
+    cb: fs_cb,
+    result: i64,
+    ptr: rawptr,
+    path: cstring,
+    statbuf: stat_t,
+    new_path: cstring,
+    file_m: file,
+    flags: i32,
+    mode: posix.mode_t,
+    nbufs: u32,
+    bufs: [^]buf_t,
+    off: posix.off_t,
+    uid: uid_t,
+    gid: gid_t,
+    atime: f64,
+    mtime: f64,
+    work_req: work,
+    bufsml: [4]buf_t,
+}
+fs_t :: fs_s
+work_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_cb_m: work_cb,
+    after_work_cb_m: after_work_cb,
+    work_req: work,
+}
+work_t :: work_s
+random_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    status: i32,
+    buf: rawptr,
+    buflen: u64,
+    cb: random_cb,
+    work_req: work,
+}
+random_t :: random_s
+env_item_s :: struct {
+    name: cstring,
+    value: cstring,
+}
+env_item_t :: env_item_s
+cpu_times_s :: struct {
+    user: u64,
+    nice: u64,
+    sys: u64,
+    idle: u64,
+    irq: u64,
+}
+cpu_info_s :: struct {
+    model: cstring,
+    speed: i32,
+    cpu_times: cpu_times_s,
+}
+cpu_info_t :: cpu_info_s
+address_union_anon_15 :: struct #raw_union {address4: posix.sockaddr_in, address6: posix.sockaddr_in6, }
+netmask_union_anon_16 :: struct #raw_union {netmask4: posix.sockaddr_in, netmask6: posix.sockaddr_in6, }
+interface_address_s :: struct {
+    name: cstring,
+    phys_addr: [6]i8,
+    is_internal: i32,
+    address: address_union_anon_15,
+    netmask: netmask_union_anon_16,
+}
+interface_address_t :: interface_address_s
+passwd_s :: struct {
+    username: cstring,
+    uid: u64,
+    gid: u64,
+    shell: cstring,
+    homedir: cstring,
+}
+passwd_t :: passwd_s
+group_s :: struct {
+    groupname: cstring,
+    gid: u64,
+    members: [^]cstring,
+}
+group_t :: group_s
+utsname_s :: struct {
+    sysname: [256]i8,
+    release: [256]i8,
+    version: [256]i8,
+    machine: [256]i8,
+}
+utsname_t :: utsname_s
+statfs_s :: struct {
+    f_type: u64,
+    f_bsize: u64,
+    f_blocks: u64,
+    f_bfree: u64,
+    f_bavail: u64,
+    f_files: u64,
+    f_ffree: u64,
+    f_spare: [4]u64,
+}
+statfs_t :: statfs_s
+metrics_s :: struct {
+    loop_count: u64,
+    events: u64,
+    events_waiting: u64,
+    reserved: ^[13]^u64,
+}
+metrics_t :: metrics_s
+loop_option :: enum u32 {LOOP_BLOCK_SIGNAL = 0, METRICS_IDLE_TIME = 1, LOOP_USE_IO_URING_SQPOLL = 2, }
+run_mode :: enum u32 {RUN_DEFAULT = 0, RUN_ONCE = 1, RUN_NOWAIT = 2, }
+malloc_func :: #type proc "c" (size: u64) -> rawptr
+realloc_func :: #type proc "c" (ptr: rawptr, size: u64) -> rawptr
+calloc_func :: #type proc "c" (count: u64, size: u64) -> rawptr
+free_func :: #type proc "c" (ptr: rawptr)
+write_cb :: #type proc "c" (req: ^write_t, status: i32)
+connect_cb :: #type proc "c" (req: ^connect_t, status: i32)
+shutdown_cb :: #type proc "c" (req: ^shutdown_t, status: i32)
+poll_cb :: #type proc "c" (handle: ^poll_t, status: i32, events: i32)
+timer_cb :: #type proc "c" (handle: ^timer_t)
+async_cb :: #type proc "c" (handle: ^async_t)
+prepare_cb :: #type proc "c" (handle: ^prepare_t)
+check_cb :: #type proc "c" (handle: ^check_t)
+idle_cb :: #type proc "c" (handle: ^idle_t)
+exit_cb :: #type proc "c" (param0: ^process_t, exit_status: i64, term_signal: i32)
+walk_cb :: #type proc "c" (handle: ^handle_t, arg: rawptr)
+fs_cb :: #type proc "c" (req: ^fs_t)
+work_cb :: #type proc "c" (req: ^work_t)
+after_work_cb :: #type proc "c" (req: ^work_t, status: i32)
+getaddrinfo_cb :: #type proc "c" (req: ^getaddrinfo_t, status: i32, res: [^]posix.addrinfo)
+getnameinfo_cb :: #type proc "c" (req: ^getnameinfo_t, status: i32, hostname: cstring, service: cstring)
+random_cb :: #type proc "c" (req: ^random_t, status: i32, buf: rawptr, buflen: u64)
+clock_id :: enum u32 {CLOCK_MONOTONIC = 0, CLOCK_REALTIME = 1, }
+timespec64_t :: struct {
+    tv_sec: i64,
+    tv_nsec: i32,
+}
+timeval_t :: struct {
+    tv_sec: i64,
+    tv_usec: i64,
+}
+timeval64_t :: struct {
+    tv_sec: i64,
+    tv_usec: i32,
+}
+fs_event_cb :: #type proc "c" (handle: ^fs_event_t, filename: cstring, events: i32, status: i32)
+fs_poll_cb :: #type proc "c" (handle: ^fs_poll_t, status: i32, prev: ^stat_t, curr: ^stat_t)
+signal_cb :: #type proc "c" (handle: ^signal_t, signum: i32)
+membership :: enum u32 {LEAVE_GROUP = 0, JOIN_GROUP = 1, }
+tcp_flags :: enum u32 {TCP_IPV6ONLY = 1, TCP_REUSEPORT = 2, }
+udp_flags :: enum u32 {UDP_IPV6ONLY = 1, UDP_PARTIAL = 2, UDP_REUSEADDR = 4, UDP_MMSG_CHUNK = 8, UDP_MMSG_FREE = 16, UDP_LINUX_RECVERR = 32, UDP_REUSEPORT = 64, UDP_RECVMMSG = 256, }
+udp_send_cb :: #type proc "c" (req: ^udp_send_t, status: i32)
+udp_recv_cb :: #type proc "c" (handle: ^udp_t, nread: i64, buf: ^buf_t, addr: ^posix.sockaddr, flags: u32)
+tty_mode_t :: enum u32 {TTY_MODE_NORMAL = 0, TTY_MODE_RAW = 1, TTY_MODE_IO = 2, }
+tty_vtermstate_t :: enum u32 {TTY_SUPPORTED = 0, TTY_UNSUPPORTED = 1, }
+poll_event :: enum u32 {READABLE = 1, WRITABLE = 2, DISCONNECT = 4, PRIORITIZED = 8, }
+stdio_flags :: enum u32 {IGNORE = 0, CREATE_PIPE = 1, INHERIT_FD = 2, INHERIT_STREAM = 4, READABLE_PIPE = 16, WRITABLE_PIPE = 32, NONBLOCK_PIPE = 64, OVERLAPPED_PIPE = 64, }
+data_union_anon_13 :: struct #raw_union {stream: ^stream_t, fd: i32, }
+stdio_container_s :: struct {
+    flags: stdio_flags,
+    data: data_union_anon_13,
+}
+stdio_container_t :: stdio_container_s
+process_options_s :: struct {
+    exit_cb_m: exit_cb,
+    file_m: cstring,
+    args: [^]cstring,
+    env: ^cstring,
+    cwd: cstring,
+    flags: u32,
+    stdio_count: i32,
+    stdio: ^stdio_container_t,
+    uid: uid_t,
+    gid: gid_t,
+}
+process_options_t :: process_options_s
+process_flags :: enum u32 {PROCESS_SETUID = 1, PROCESS_SETGID = 2, PROCESS_WINDOWS_VERBATIM_ARGUMENTS = 4, PROCESS_DETACHED = 8, PROCESS_WINDOWS_HIDE = 16, PROCESS_WINDOWS_HIDE_CONSOLE = 32, PROCESS_WINDOWS_HIDE_GUI = 64, PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = 128, }
+rusage_t :: struct {
+    ru_utime: timeval_t,
+    ru_stime: timeval_t,
+    ru_maxrss: u64,
+    ru_ixrss: u64,
+    ru_idrss: u64,
+    ru_isrss: u64,
+    ru_minflt: u64,
+    ru_majflt: u64,
+    ru_nswap: u64,
+    ru_inblock: u64,
+    ru_oublock: u64,
+    ru_msgsnd: u64,
+    ru_msgrcv: u64,
+    ru_nsignals: u64,
+    ru_nvcsw: u64,
+    ru_nivcsw: u64,
+}
+fs_event :: enum u32 {RENAME = 1, CHANGE = 2, }
+tree_entry_struct_anon_20 :: struct {
+    rbe_left: ^signal_s,
+    rbe_right: ^signal_s,
+    rbe_parent: ^signal_s,
+    rbe_color: i32,
+}
+fs_event_flags :: enum u32 {FS_EVENT_WATCH_ENTRY = 1, FS_EVENT_STAT = 2, FS_EVENT_RECURSIVE = 4, }
+callback_func_ptr_anon_21 :: #type proc "c" ()
+thread_cb :: #type proc "c" (arg: rawptr)
+thread_create_flags :: enum u32 {THREAD_NO_FLAGS = 0, THREAD_HAS_STACK_SIZE = 1, }
+thread_options_s :: struct {
+    flags: u32,
+    stack_size: u64,
+}
+thread_options_t :: thread_options_s
+any_handle :: struct #raw_union {async: async_t, check: check_t, fs_event_m: fs_event_t, fs_poll: fs_poll_t, handle: handle_t, idle: idle_t, pipe: pipe_t, poll: poll_t, prepare: prepare_t, process: process_t, stream: stream_t, tcp: tcp_t, timer: timer_t, tty: tty_t, udp: udp_t, signal: signal_t, }
+any_req :: struct #raw_union {req: req_t, connect: connect_t, write: write_t, shutdown: shutdown_t, udp_send: udp_send_t, fs: fs_t, work_m: work_t, getaddrinfo: getaddrinfo_t, getnameinfo: getnameinfo_t, random: random_t, }
+work_func_ptr_anon_25 :: #type proc "c" (w: ^work)
+done_func_ptr_anon_26 :: #type proc "c" (w: ^work, status: i32)
+os_fd_t :: i32
+os_sock_t :: i32
+pid_t :: linux.Pid
+thread_t :: posix.pthread_t
+lib_t :: struct {
+    handle: rawptr,
+    errmsg: cstring,
+}
+sem_t :: [32]u8
+cond_t :: posix.pthread_cond_t
 _uv_barrier :: struct {
-	mutex:     uv_mutex_t,
-	cond:      uv_cond_t,
-	threshold: u32,
-	in_m:      u32,
-	out:       u32,
+    mutex: mutex_t,
+    cond: cond_t,
+    threshold: u32,
+    in_m: u32,
+    out: u32,
 }
-uv_barrier_t :: struct {
-	b: ^_uv_barrier,
+barrier_t :: struct {
+    b: ^_uv_barrier,
 }
-uv_once_t :: i32
-uv_key_t :: i32
+key_t :: posix.pthread_key_t
 
-foreign import uv_runic "system:libuv.a"
+when #config(UV_STATIC, false) {
+    foreign import uv_runic "system:libuv.a"
+} else {
+    foreign import uv_runic "system:uv"
+}
 
 @(default_calling_convention = "c")
 foreign uv_runic {
-	@(link_name = "uv_version")
-	version :: proc() -> u32 ---
+    @(link_name = "uv_version")
+    version :: proc() -> u32 ---
 
-	@(link_name = "uv_version_string")
-	version_string :: proc() -> cstring ---
+    @(link_name = "uv_version_string")
+    version_string :: proc() -> cstring ---
 
-	@(link_name = "uv_library_shutdown")
-	library_shutdown :: proc() ---
+    @(link_name = "uv_library_shutdown")
+    library_shutdown :: proc() ---
 
-	@(link_name = "uv_replace_allocator")
-	replace_allocator :: proc(malloc_func: uv_malloc_func, realloc_func: uv_realloc_func, calloc_func: uv_calloc_func, free_func: uv_free_func) -> i32 ---
+    @(link_name = "uv_replace_allocator")
+    replace_allocator :: proc(malloc_func_p: malloc_func, realloc_func_p: realloc_func, calloc_func_p: calloc_func, free_func_p: free_func) -> i32 ---
 
-	@(link_name = "uv_default_loop")
-	default_loop :: proc() -> ^uv_loop_t ---
+    @(link_name = "uv_default_loop")
+    default_loop :: proc() -> ^loop_t ---
 
-	@(link_name = "uv_loop_init")
-	loop_init :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_init")
+    loop_init :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_close")
-	loop_close :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_close")
+    loop_close :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_new")
-	loop_new :: proc() -> ^uv_loop_t ---
+    @(link_name = "uv_loop_new")
+    loop_new :: proc() -> ^loop_t ---
 
-	@(link_name = "uv_loop_delete")
-	loop_delete :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_loop_delete")
+    loop_delete :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_loop_size")
-	loop_size :: proc() -> i32 ---
+    @(link_name = "uv_loop_size")
+    loop_size :: proc() -> u64 ---
 
-	@(link_name = "uv_loop_alive")
-	loop_alive :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_alive")
+    loop_alive :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_configure")
-	loop_configure :: proc(loop: ^uv_loop_t, option: uv_loop_option) -> i32 ---
+    @(link_name = "uv_loop_configure")
+    loop_configure :: proc(loop: ^loop_t, option: loop_option, #c_vararg var_args: ..any) -> i32 ---
 
-	@(link_name = "uv_loop_fork")
-	loop_fork :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_fork")
+    loop_fork :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_run")
-	run :: proc(param0: ^uv_loop_t, mode: uv_run_mode) -> i32 ---
+    @(link_name = "uv_run")
+    run :: proc(param0: ^loop_t, mode: run_mode) -> i32 ---
 
-	@(link_name = "uv_stop")
-	stop :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_stop")
+    stop :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_ref")
-	ref :: proc(param0: ^uv_handle_t) ---
+    @(link_name = "uv_ref")
+    ref :: proc(param0: ^handle_t) ---
 
-	@(link_name = "uv_unref")
-	unref :: proc(param0: ^uv_handle_t) ---
+    @(link_name = "uv_unref")
+    unref :: proc(param0: ^handle_t) ---
 
-	@(link_name = "uv_has_ref")
-	has_ref :: proc(param0: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_has_ref")
+    has_ref :: proc(param0: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_update_time")
-	update_time :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_update_time")
+    update_time :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_now")
-	now :: proc(param0: ^uv_loop_t) -> u64 ---
+    @(link_name = "uv_now")
+    now :: proc(param0: ^loop_t) -> u64 ---
 
-	@(link_name = "uv_backend_fd")
-	backend_fd :: proc(param0: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_backend_fd")
+    backend_fd :: proc(param0: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_backend_timeout")
-	backend_timeout :: proc(param0: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_backend_timeout")
+    backend_timeout :: proc(param0: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_translate_sys_error")
-	translate_sys_error :: proc(sys_errno: i32) -> i32 ---
+    @(link_name = "uv_translate_sys_error")
+    translate_sys_error :: proc(sys_errno: i32) -> i32 ---
 
-	@(link_name = "uv_strerror")
-	strerror :: proc(err: i32) -> cstring ---
+    @(link_name = "uv_strerror")
+    strerror :: proc(err: i32) -> cstring ---
 
-	@(link_name = "uv_strerror_r")
-	strerror_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
+    @(link_name = "uv_strerror_r")
+    strerror_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
 
-	@(link_name = "uv_err_name")
-	err_name :: proc(err: i32) -> cstring ---
+    @(link_name = "uv_err_name")
+    err_name :: proc(err: i32) -> cstring ---
 
-	@(link_name = "uv_err_name_r")
-	err_name_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
+    @(link_name = "uv_err_name_r")
+    err_name_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
 
-	@(link_name = "uv_shutdown")
-	shutdown :: proc(req: ^uv_shutdown_t, handle: ^uv_stream_t, cb: uv_shutdown_cb) -> i32 ---
+    @(link_name = "uv_shutdown")
+    shutdown :: proc(req: ^shutdown_t, handle: ^stream_t, cb: shutdown_cb) -> i32 ---
 
-	@(link_name = "uv_handle_size")
-	handle_size :: proc(type: uv_handle_type) -> i32 ---
+    @(link_name = "uv_handle_size")
+    handle_size :: proc(type: handle_type) -> u64 ---
 
-	@(link_name = "uv_handle_get_type")
-	handle_get_type :: proc(handle: ^uv_handle_t) -> uv_handle_type ---
+    @(link_name = "uv_handle_get_type")
+    handle_get_type :: proc(handle: ^handle_t) -> handle_type ---
 
-	@(link_name = "uv_handle_type_name")
-	handle_type_name :: proc(type: uv_handle_type) -> cstring ---
+    @(link_name = "uv_handle_type_name")
+    handle_type_name :: proc(type: handle_type) -> cstring ---
 
-	@(link_name = "uv_handle_get_data")
-	handle_get_data :: proc(handle: ^uv_handle_t) -> rawptr ---
+    @(link_name = "uv_handle_get_data")
+    handle_get_data :: proc(handle: ^handle_t) -> rawptr ---
 
-	@(link_name = "uv_handle_get_loop")
-	handle_get_loop :: proc(handle: ^uv_handle_t) -> ^uv_loop_t ---
+    @(link_name = "uv_handle_get_loop")
+    handle_get_loop :: proc(handle: ^handle_t) -> ^loop_t ---
 
-	@(link_name = "uv_handle_set_data")
-	handle_set_data :: proc(handle: ^uv_handle_t, data: rawptr) ---
+    @(link_name = "uv_handle_set_data")
+    handle_set_data :: proc(handle: ^handle_t, data: rawptr) ---
 
-	@(link_name = "uv_req_size")
-	req_size :: proc(type: uv_req_type) -> i32 ---
+    @(link_name = "uv_req_size")
+    req_size :: proc(type: req_type) -> u64 ---
 
-	@(link_name = "uv_req_get_data")
-	req_get_data :: proc(req: ^uv_req_t) -> rawptr ---
+    @(link_name = "uv_req_get_data")
+    req_get_data :: proc(req: ^req_t) -> rawptr ---
 
-	@(link_name = "uv_req_set_data")
-	req_set_data :: proc(req: ^uv_req_t, data: rawptr) ---
+    @(link_name = "uv_req_set_data")
+    req_set_data :: proc(req: ^req_t, data: rawptr) ---
 
-	@(link_name = "uv_req_get_type")
-	req_get_type :: proc(req: ^uv_req_t) -> uv_req_type ---
+    @(link_name = "uv_req_get_type")
+    req_get_type :: proc(req: ^req_t) -> req_type ---
 
-	@(link_name = "uv_req_type_name")
-	req_type_name :: proc(type: uv_req_type) -> cstring ---
+    @(link_name = "uv_req_type_name")
+    req_type_name :: proc(type: req_type) -> cstring ---
 
-	@(link_name = "uv_is_active")
-	is_active :: proc(handle: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_is_active")
+    is_active :: proc(handle: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_walk")
-	walk :: proc(loop: ^uv_loop_t, walk_cb: uv_walk_cb, arg: rawptr) ---
+    @(link_name = "uv_walk")
+    walk :: proc(loop: ^loop_t, walk_cb_p: walk_cb, arg: rawptr) ---
 
-	@(link_name = "uv_print_all_handles")
-	print_all_handles :: proc(loop: ^uv_loop_t, stream: ^FILE) ---
+    @(link_name = "uv_print_all_handles")
+    print_all_handles :: proc(loop: ^loop_t, stream: ^libc.FILE) ---
 
-	@(link_name = "uv_print_active_handles")
-	print_active_handles :: proc(loop: ^uv_loop_t, stream: ^FILE) ---
+    @(link_name = "uv_print_active_handles")
+    print_active_handles :: proc(loop: ^loop_t, stream: ^libc.FILE) ---
 
-	@(link_name = "uv_close")
-	close :: proc(handle: ^uv_handle_t, close_cb: uv_close_cb) ---
+    @(link_name = "uv_close")
+    close :: proc(handle: ^handle_t, close_cb_p: close_cb) ---
 
-	@(link_name = "uv_send_buffer_size")
-	send_buffer_size :: proc(handle: ^uv_handle_t, value: ^i32) -> i32 ---
+    @(link_name = "uv_send_buffer_size")
+    send_buffer_size :: proc(handle: ^handle_t, value: ^i32) -> i32 ---
 
-	@(link_name = "uv_recv_buffer_size")
-	recv_buffer_size :: proc(handle: ^uv_handle_t, value: ^i32) -> i32 ---
+    @(link_name = "uv_recv_buffer_size")
+    recv_buffer_size :: proc(handle: ^handle_t, value: ^i32) -> i32 ---
 
-	@(link_name = "uv_fileno")
-	fileno :: proc(handle: ^uv_handle_t, fd: ^uv_os_fd_t) -> i32 ---
+    @(link_name = "uv_fileno")
+    fileno :: proc(handle: ^handle_t, fd: ^os_fd_t) -> i32 ---
 
-	@(link_name = "uv_buf_init")
-	buf_init :: proc(base: cstring, len: u32) -> uv_buf_t ---
+    @(link_name = "uv_buf_init")
+    buf_init :: proc(base: cstring, len: u32) -> buf_t ---
 
-	@(link_name = "uv_pipe")
-	pipe :: proc(fds: [2]uv_file, read_flags: i32, write_flags: i32) -> i32 ---
+    @(link_name = "uv_pipe")
+    pipe :: proc(fds: [2]file, read_flags: i32, write_flags: i32) -> i32 ---
 
-	@(link_name = "uv_socketpair")
-	socketpair :: proc(type: i32, protocol: i32, socket_vector: [2]uv_os_sock_t, flags0: i32, flags1: i32) -> i32 ---
+    @(link_name = "uv_socketpair")
+    socketpair :: proc(type: i32, protocol: i32, socket_vector: [2]os_sock_t, flags0: i32, flags1: i32) -> i32 ---
 
-	@(link_name = "uv_stream_get_write_queue_size")
-	stream_get_write_queue_size :: proc(stream: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_stream_get_write_queue_size")
+    stream_get_write_queue_size :: proc(stream: ^stream_t) -> u64 ---
 
-	@(link_name = "uv_listen")
-	listen :: proc(stream: ^uv_stream_t, backlog: i32, cb: uv_connection_cb) -> i32 ---
+    @(link_name = "uv_listen")
+    listen :: proc(stream: ^stream_t, backlog: i32, cb: connection_cb) -> i32 ---
 
-	@(link_name = "uv_accept")
-	accept :: proc(server: ^uv_stream_t, client: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_accept")
+    accept :: proc(server: ^stream_t, client: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_read_start")
-	read_start :: proc(param0: ^uv_stream_t, alloc_cb: uv_alloc_cb, read_cb: uv_read_cb) -> i32 ---
+    @(link_name = "uv_read_start")
+    read_start :: proc(param0: ^stream_t, alloc_cb_p: alloc_cb, read_cb_p: read_cb) -> i32 ---
 
-	@(link_name = "uv_read_stop")
-	read_stop :: proc(param0: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_read_stop")
+    read_stop :: proc(param0: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_write")
-	write :: proc(req: ^uv_write_t, handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, cb: uv_write_cb) -> i32 ---
+    @(link_name = "uv_write")
+    write :: proc(req: ^write_t, handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, cb: write_cb) -> i32 ---
 
-	@(link_name = "uv_write2")
-	write2 :: proc(req: ^uv_write_t, handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, send_handle: ^uv_stream_t, cb: uv_write_cb) -> i32 ---
+    @(link_name = "uv_write2")
+    write2 :: proc(req: ^write_t, handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, send_handle: ^stream_t, cb: write_cb) -> i32 ---
 
-	@(link_name = "uv_try_write")
-	try_write :: proc(handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32) -> i32 ---
+    @(link_name = "uv_try_write")
+    try_write :: proc(handle: ^stream_t, bufs: [^]buf_t, nbufs: u32) -> i32 ---
 
-	@(link_name = "uv_try_write2")
-	try_write2 :: proc(handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, send_handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_try_write2")
+    try_write2 :: proc(handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, send_handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_is_readable")
-	is_readable :: proc(handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_is_readable")
+    is_readable :: proc(handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_is_writable")
-	is_writable :: proc(handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_is_writable")
+    is_writable :: proc(handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_stream_set_blocking")
-	stream_set_blocking :: proc(handle: ^uv_stream_t, blocking: i32) -> i32 ---
+    @(link_name = "uv_stream_set_blocking")
+    stream_set_blocking :: proc(handle: ^stream_t, blocking: i32) -> i32 ---
 
-	@(link_name = "uv_is_closing")
-	is_closing :: proc(handle: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_is_closing")
+    is_closing :: proc(handle: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_tcp_init")
-	tcp_init :: proc(param0: ^uv_loop_t, handle: ^uv_tcp_t) -> i32 ---
+    @(link_name = "uv_tcp_init")
+    tcp_init :: proc(param0: ^loop_t, handle: ^tcp_t) -> i32 ---
 
-	@(link_name = "uv_tcp_init_ex")
-	tcp_init_ex :: proc(param0: ^uv_loop_t, handle: ^uv_tcp_t, flags: u32) -> i32 ---
+    @(link_name = "uv_tcp_init_ex")
+    tcp_init_ex :: proc(param0: ^loop_t, handle: ^tcp_t, flags: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_open")
-	tcp_open :: proc(handle: ^uv_tcp_t, sock: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_tcp_open")
+    tcp_open :: proc(handle: ^tcp_t, sock: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_tcp_nodelay")
-	tcp_nodelay :: proc(handle: ^uv_tcp_t, enable: i32) -> i32 ---
+    @(link_name = "uv_tcp_nodelay")
+    tcp_nodelay :: proc(handle: ^tcp_t, enable: i32) -> i32 ---
 
-	@(link_name = "uv_tcp_keepalive")
-	tcp_keepalive :: proc(handle: ^uv_tcp_t, enable: i32, delay: u32) -> i32 ---
+    @(link_name = "uv_tcp_keepalive")
+    tcp_keepalive :: proc(handle: ^tcp_t, enable: i32, delay: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_simultaneous_accepts")
-	tcp_simultaneous_accepts :: proc(handle: ^uv_tcp_t, enable: i32) -> i32 ---
+    @(link_name = "uv_tcp_simultaneous_accepts")
+    tcp_simultaneous_accepts :: proc(handle: ^tcp_t, enable: i32) -> i32 ---
 
-	@(link_name = "uv_tcp_bind")
-	tcp_bind :: proc(handle: ^uv_tcp_t, addr: ^sockaddr, flags: u32) -> i32 ---
+    @(link_name = "uv_tcp_bind")
+    tcp_bind :: proc(handle: ^tcp_t, addr: ^posix.sockaddr, flags: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_getsockname")
-	tcp_getsockname :: proc(handle: ^uv_tcp_t, name: ^sockaddr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_tcp_getsockname")
+    tcp_getsockname :: proc(handle: ^tcp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_tcp_getpeername")
-	tcp_getpeername :: proc(handle: ^uv_tcp_t, name: ^sockaddr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_tcp_getpeername")
+    tcp_getpeername :: proc(handle: ^tcp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_tcp_close_reset")
-	tcp_close_reset :: proc(handle: ^uv_tcp_t, close_cb: uv_close_cb) -> i32 ---
+    @(link_name = "uv_tcp_close_reset")
+    tcp_close_reset :: proc(handle: ^tcp_t, close_cb_p: close_cb) -> i32 ---
 
-	@(link_name = "uv_tcp_connect")
-	tcp_connect :: proc(req: ^uv_connect_t, handle: ^uv_tcp_t, addr: ^sockaddr, cb: uv_connect_cb) -> i32 ---
+    @(link_name = "uv_tcp_connect")
+    tcp_connect :: proc(req: ^connect_t, handle: ^tcp_t, addr: ^posix.sockaddr, cb: connect_cb) -> i32 ---
 
-	@(link_name = "uv_udp_init")
-	udp_init :: proc(param0: ^uv_loop_t, handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_init")
+    udp_init :: proc(param0: ^loop_t, handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_init_ex")
-	udp_init_ex :: proc(param0: ^uv_loop_t, handle: ^uv_udp_t, flags: u32) -> i32 ---
+    @(link_name = "uv_udp_init_ex")
+    udp_init_ex :: proc(param0: ^loop_t, handle: ^udp_t, flags: u32) -> i32 ---
 
-	@(link_name = "uv_udp_open")
-	udp_open :: proc(handle: ^uv_udp_t, sock: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_udp_open")
+    udp_open :: proc(handle: ^udp_t, sock: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_udp_bind")
-	udp_bind :: proc(handle: ^uv_udp_t, addr: ^sockaddr, flags: u32) -> i32 ---
+    @(link_name = "uv_udp_bind")
+    udp_bind :: proc(handle: ^udp_t, addr: ^posix.sockaddr, flags: u32) -> i32 ---
 
-	@(link_name = "uv_udp_connect")
-	udp_connect :: proc(handle: ^uv_udp_t, addr: ^sockaddr) -> i32 ---
+    @(link_name = "uv_udp_connect")
+    udp_connect :: proc(handle: ^udp_t, addr: ^posix.sockaddr) -> i32 ---
 
-	@(link_name = "uv_udp_getpeername")
-	udp_getpeername :: proc(handle: ^uv_udp_t, name: ^sockaddr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_udp_getpeername")
+    udp_getpeername :: proc(handle: ^udp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_udp_getsockname")
-	udp_getsockname :: proc(handle: ^uv_udp_t, name: ^sockaddr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_udp_getsockname")
+    udp_getsockname :: proc(handle: ^udp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_membership")
-	udp_set_membership :: proc(handle: ^uv_udp_t, multicast_addr: cstring, interface_addr: cstring, membership: uv_membership) -> i32 ---
+    @(link_name = "uv_udp_set_membership")
+    udp_set_membership :: proc(handle: ^udp_t, multicast_addr: cstring, interface_addr: cstring, membership_p: membership) -> i32 ---
 
-	@(link_name = "uv_udp_set_source_membership")
-	udp_set_source_membership :: proc(handle: ^uv_udp_t, multicast_addr: cstring, interface_addr: cstring, source_addr: cstring, membership: uv_membership) -> i32 ---
+    @(link_name = "uv_udp_set_source_membership")
+    udp_set_source_membership :: proc(handle: ^udp_t, multicast_addr: cstring, interface_addr: cstring, source_addr: cstring, membership_p: membership) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_loop")
-	udp_set_multicast_loop :: proc(handle: ^uv_udp_t, on: i32) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_loop")
+    udp_set_multicast_loop :: proc(handle: ^udp_t, on: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_ttl")
-	udp_set_multicast_ttl :: proc(handle: ^uv_udp_t, ttl: i32) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_ttl")
+    udp_set_multicast_ttl :: proc(handle: ^udp_t, ttl: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_interface")
-	udp_set_multicast_interface :: proc(handle: ^uv_udp_t, interface_addr: cstring) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_interface")
+    udp_set_multicast_interface :: proc(handle: ^udp_t, interface_addr: cstring) -> i32 ---
 
-	@(link_name = "uv_udp_set_broadcast")
-	udp_set_broadcast :: proc(handle: ^uv_udp_t, on: i32) -> i32 ---
+    @(link_name = "uv_udp_set_broadcast")
+    udp_set_broadcast :: proc(handle: ^udp_t, on: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_ttl")
-	udp_set_ttl :: proc(handle: ^uv_udp_t, ttl: i32) -> i32 ---
+    @(link_name = "uv_udp_set_ttl")
+    udp_set_ttl :: proc(handle: ^udp_t, ttl: i32) -> i32 ---
 
-	@(link_name = "uv_udp_send")
-	udp_send :: proc(req: ^uv_udp_send_t, handle: ^uv_udp_t, bufs: [^]uv_buf_t, nbufs: u32, addr: ^sockaddr, send_cb: uv_udp_send_cb) -> i32 ---
+    @(link_name = "uv_udp_send")
+    udp_send :: proc(req: ^udp_send_t, handle: ^udp_t, bufs: [^]buf_t, nbufs: u32, addr: ^posix.sockaddr, send_cb: udp_send_cb) -> i32 ---
 
-	@(link_name = "uv_udp_try_send")
-	udp_try_send :: proc(handle: ^uv_udp_t, bufs: [^]uv_buf_t, nbufs: u32, addr: ^sockaddr) -> i32 ---
+    @(link_name = "uv_udp_try_send")
+    udp_try_send :: proc(handle: ^udp_t, bufs: [^]buf_t, nbufs: u32, addr: ^posix.sockaddr) -> i32 ---
 
-	@(link_name = "uv_udp_recv_start")
-	udp_recv_start :: proc(handle: ^uv_udp_t, alloc_cb: uv_alloc_cb, recv_cb: uv_udp_recv_cb) -> i32 ---
+    @(link_name = "uv_udp_recv_start")
+    udp_recv_start :: proc(handle: ^udp_t, alloc_cb_p: alloc_cb, recv_cb: udp_recv_cb) -> i32 ---
 
-	@(link_name = "uv_udp_using_recvmmsg")
-	udp_using_recvmmsg :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_using_recvmmsg")
+    udp_using_recvmmsg :: proc(handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_recv_stop")
-	udp_recv_stop :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_recv_stop")
+    udp_recv_stop :: proc(handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_get_send_queue_size")
-	udp_get_send_queue_size :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_get_send_queue_size")
+    udp_get_send_queue_size :: proc(handle: ^udp_t) -> u64 ---
 
-	@(link_name = "uv_udp_get_send_queue_count")
-	udp_get_send_queue_count :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_get_send_queue_count")
+    udp_get_send_queue_count :: proc(handle: ^udp_t) -> u64 ---
 
-	@(link_name = "uv_tty_init")
-	tty_init :: proc(param0: ^uv_loop_t, param1: ^uv_tty_t, fd: uv_file, readable: i32) -> i32 ---
+    @(link_name = "uv_tty_init")
+    tty_init :: proc(param0: ^loop_t, param1: ^tty_t, fd: file, readable: i32) -> i32 ---
 
-	@(link_name = "uv_tty_set_mode")
-	tty_set_mode :: proc(param0: ^uv_tty_t, mode: uv_tty_mode_t) -> i32 ---
+    @(link_name = "uv_tty_set_mode")
+    tty_set_mode :: proc(param0: ^tty_t, mode: tty_mode_t) -> i32 ---
 
-	@(link_name = "uv_tty_reset_mode")
-	tty_reset_mode :: proc() -> i32 ---
+    @(link_name = "uv_tty_reset_mode")
+    tty_reset_mode :: proc() -> i32 ---
 
-	@(link_name = "uv_tty_get_winsize")
-	tty_get_winsize :: proc(param0: ^uv_tty_t, width: ^i32, height: ^i32) -> i32 ---
+    @(link_name = "uv_tty_get_winsize")
+    tty_get_winsize :: proc(param0: ^tty_t, width: ^i32, height: ^i32) -> i32 ---
 
-	@(link_name = "uv_tty_set_vterm_state")
-	tty_set_vterm_state :: proc(state: uv_tty_vtermstate_t) ---
+    @(link_name = "uv_tty_set_vterm_state")
+    tty_set_vterm_state :: proc(state: tty_vtermstate_t) ---
 
-	@(link_name = "uv_tty_get_vterm_state")
-	tty_get_vterm_state :: proc(state: ^uv_tty_vtermstate_t) -> i32 ---
+    @(link_name = "uv_tty_get_vterm_state")
+    tty_get_vterm_state :: proc(state: ^tty_vtermstate_t) -> i32 ---
 
-	@(link_name = "uv_guess_handle")
-	guess_handle :: proc(file: uv_file) -> uv_handle_type ---
+    @(link_name = "uv_guess_handle")
+    guess_handle :: proc(file_p: file) -> handle_type ---
 
-	@(link_name = "uv_pipe_init")
-	pipe_init :: proc(param0: ^uv_loop_t, handle: ^uv_pipe_t, ipc: i32) -> i32 ---
+    @(link_name = "uv_pipe_init")
+    pipe_init :: proc(param0: ^loop_t, handle: ^pipe_t, ipc: i32) -> i32 ---
 
-	@(link_name = "uv_pipe_open")
-	pipe_open :: proc(param0: ^uv_pipe_t, file: uv_file) -> i32 ---
+    @(link_name = "uv_pipe_open")
+    pipe_open :: proc(param0: ^pipe_t, file_p: file) -> i32 ---
 
-	@(link_name = "uv_pipe_bind")
-	pipe_bind :: proc(handle: ^uv_pipe_t, name: cstring) -> i32 ---
+    @(link_name = "uv_pipe_bind")
+    pipe_bind :: proc(handle: ^pipe_t, name: cstring) -> i32 ---
 
-	@(link_name = "uv_pipe_bind2")
-	pipe_bind2 :: proc(handle: ^uv_pipe_t, name: cstring, namelen: u64, flags: u32) -> i32 ---
+    @(link_name = "uv_pipe_bind2")
+    pipe_bind2 :: proc(handle: ^pipe_t, name: cstring, namelen: u64, flags: u32) -> i32 ---
 
-	@(link_name = "uv_pipe_connect")
-	pipe_connect :: proc(req: ^uv_connect_t, handle: ^uv_pipe_t, name: cstring, cb: uv_connect_cb) ---
+    @(link_name = "uv_pipe_connect")
+    pipe_connect :: proc(req: ^connect_t, handle: ^pipe_t, name: cstring, cb: connect_cb) ---
 
-	@(link_name = "uv_pipe_connect2")
-	pipe_connect2 :: proc(req: ^uv_connect_t, handle: ^uv_pipe_t, name: cstring, namelen: u64, flags: u32, cb: uv_connect_cb) -> i32 ---
+    @(link_name = "uv_pipe_connect2")
+    pipe_connect2 :: proc(req: ^connect_t, handle: ^pipe_t, name: cstring, namelen: u64, flags: u32, cb: connect_cb) -> i32 ---
 
-	@(link_name = "uv_pipe_getsockname")
-	pipe_getsockname :: proc(handle: ^uv_pipe_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_pipe_getsockname")
+    pipe_getsockname :: proc(handle: ^pipe_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_pipe_getpeername")
-	pipe_getpeername :: proc(handle: ^uv_pipe_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_pipe_getpeername")
+    pipe_getpeername :: proc(handle: ^pipe_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_pipe_pending_instances")
-	pipe_pending_instances :: proc(handle: ^uv_pipe_t, count: i32) ---
+    @(link_name = "uv_pipe_pending_instances")
+    pipe_pending_instances :: proc(handle: ^pipe_t, count: i32) ---
 
-	@(link_name = "uv_pipe_pending_count")
-	pipe_pending_count :: proc(handle: ^uv_pipe_t) -> i32 ---
+    @(link_name = "uv_pipe_pending_count")
+    pipe_pending_count :: proc(handle: ^pipe_t) -> i32 ---
 
-	@(link_name = "uv_pipe_pending_type")
-	pipe_pending_type :: proc(handle: ^uv_pipe_t) -> uv_handle_type ---
+    @(link_name = "uv_pipe_pending_type")
+    pipe_pending_type :: proc(handle: ^pipe_t) -> handle_type ---
 
-	@(link_name = "uv_pipe_chmod")
-	pipe_chmod :: proc(handle: ^uv_pipe_t, flags: i32) -> i32 ---
+    @(link_name = "uv_pipe_chmod")
+    pipe_chmod :: proc(handle: ^pipe_t, flags: i32) -> i32 ---
 
-	@(link_name = "uv_poll_init")
-	poll_init :: proc(loop: ^uv_loop_t, handle: ^uv_poll_t, fd: i32) -> i32 ---
+    @(link_name = "uv_poll_init")
+    poll_init :: proc(loop: ^loop_t, handle: ^poll_t, fd: i32) -> i32 ---
 
-	@(link_name = "uv_poll_init_socket")
-	poll_init_socket :: proc(loop: ^uv_loop_t, handle: ^uv_poll_t, socket: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_poll_init_socket")
+    poll_init_socket :: proc(loop: ^loop_t, handle: ^poll_t, socket: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_poll_start")
-	poll_start :: proc(handle: ^uv_poll_t, events: i32, cb: uv_poll_cb) -> i32 ---
+    @(link_name = "uv_poll_start")
+    poll_start :: proc(handle: ^poll_t, events: i32, cb: poll_cb) -> i32 ---
 
-	@(link_name = "uv_poll_stop")
-	poll_stop :: proc(handle: ^uv_poll_t) -> i32 ---
+    @(link_name = "uv_poll_stop")
+    poll_stop :: proc(handle: ^poll_t) -> i32 ---
 
-	@(link_name = "uv_prepare_init")
-	prepare_init :: proc(param0: ^uv_loop_t, prepare: ^uv_prepare_t) -> i32 ---
+    @(link_name = "uv_prepare_init")
+    prepare_init :: proc(param0: ^loop_t, prepare: ^prepare_t) -> i32 ---
 
-	@(link_name = "uv_prepare_start")
-	prepare_start :: proc(prepare: ^uv_prepare_t, cb: uv_prepare_cb) -> i32 ---
+    @(link_name = "uv_prepare_start")
+    prepare_start :: proc(prepare: ^prepare_t, cb: prepare_cb) -> i32 ---
 
-	@(link_name = "uv_prepare_stop")
-	prepare_stop :: proc(prepare: ^uv_prepare_t) -> i32 ---
+    @(link_name = "uv_prepare_stop")
+    prepare_stop :: proc(prepare: ^prepare_t) -> i32 ---
 
-	@(link_name = "uv_check_init")
-	check_init :: proc(param0: ^uv_loop_t, check: ^uv_check_t) -> i32 ---
+    @(link_name = "uv_check_init")
+    check_init :: proc(param0: ^loop_t, check: ^check_t) -> i32 ---
 
-	@(link_name = "uv_check_start")
-	check_start :: proc(check: ^uv_check_t, cb: uv_check_cb) -> i32 ---
+    @(link_name = "uv_check_start")
+    check_start :: proc(check: ^check_t, cb: check_cb) -> i32 ---
 
-	@(link_name = "uv_check_stop")
-	check_stop :: proc(check: ^uv_check_t) -> i32 ---
+    @(link_name = "uv_check_stop")
+    check_stop :: proc(check: ^check_t) -> i32 ---
 
-	@(link_name = "uv_idle_init")
-	idle_init :: proc(param0: ^uv_loop_t, idle: ^uv_idle_t) -> i32 ---
+    @(link_name = "uv_idle_init")
+    idle_init :: proc(param0: ^loop_t, idle: ^idle_t) -> i32 ---
 
-	@(link_name = "uv_idle_start")
-	idle_start :: proc(idle: ^uv_idle_t, cb: uv_idle_cb) -> i32 ---
+    @(link_name = "uv_idle_start")
+    idle_start :: proc(idle: ^idle_t, cb: idle_cb) -> i32 ---
 
-	@(link_name = "uv_idle_stop")
-	idle_stop :: proc(idle: ^uv_idle_t) -> i32 ---
+    @(link_name = "uv_idle_stop")
+    idle_stop :: proc(idle: ^idle_t) -> i32 ---
 
-	@(link_name = "uv_async_init")
-	async_init :: proc(param0: ^uv_loop_t, async: ^uv_async_t, async_cb: uv_async_cb) -> i32 ---
+    @(link_name = "uv_async_init")
+    async_init :: proc(param0: ^loop_t, async: ^async_t, async_cb_p: async_cb) -> i32 ---
 
-	@(link_name = "uv_async_send")
-	async_send :: proc(async: ^uv_async_t) -> i32 ---
+    @(link_name = "uv_async_send")
+    async_send :: proc(async: ^async_t) -> i32 ---
 
-	@(link_name = "uv_timer_init")
-	timer_init :: proc(param0: ^uv_loop_t, handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_init")
+    timer_init :: proc(param0: ^loop_t, handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_start")
-	timer_start :: proc(handle: ^uv_timer_t, cb: uv_timer_cb, timeout: u64, repeat: u64) -> i32 ---
+    @(link_name = "uv_timer_start")
+    timer_start :: proc(handle: ^timer_t, cb: timer_cb, timeout: u64, repeat: u64) -> i32 ---
 
-	@(link_name = "uv_timer_stop")
-	timer_stop :: proc(handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_stop")
+    timer_stop :: proc(handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_again")
-	timer_again :: proc(handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_again")
+    timer_again :: proc(handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_set_repeat")
-	timer_set_repeat :: proc(handle: ^uv_timer_t, repeat: u64) ---
+    @(link_name = "uv_timer_set_repeat")
+    timer_set_repeat :: proc(handle: ^timer_t, repeat: u64) ---
 
-	@(link_name = "uv_timer_get_repeat")
-	timer_get_repeat :: proc(handle: ^uv_timer_t) -> u64 ---
+    @(link_name = "uv_timer_get_repeat")
+    timer_get_repeat :: proc(handle: ^timer_t) -> u64 ---
 
-	@(link_name = "uv_timer_get_due_in")
-	timer_get_due_in :: proc(handle: ^uv_timer_t) -> u64 ---
+    @(link_name = "uv_timer_get_due_in")
+    timer_get_due_in :: proc(handle: ^timer_t) -> u64 ---
 
-	@(link_name = "uv_getaddrinfo")
-	getaddrinfo :: proc(loop: ^uv_loop_t, req: ^uv_getaddrinfo_t, getaddrinfo_cb: uv_getaddrinfo_cb, node: cstring, service: cstring, hints: [^]addrinfo) -> i32 ---
+    @(link_name = "uv_getaddrinfo")
+    getaddrinfo :: proc(loop: ^loop_t, req: ^getaddrinfo_t, getaddrinfo_cb_p: getaddrinfo_cb, node: cstring, service: cstring, hints: [^]posix.addrinfo) -> i32 ---
 
-	@(link_name = "uv_freeaddrinfo")
-	freeaddrinfo :: proc(ai: ^addrinfo) ---
+    @(link_name = "uv_freeaddrinfo")
+    freeaddrinfo :: proc(ai: ^posix.addrinfo) ---
 
-	@(link_name = "uv_getnameinfo")
-	getnameinfo :: proc(loop: ^uv_loop_t, req: ^uv_getnameinfo_t, getnameinfo_cb: uv_getnameinfo_cb, addr: ^sockaddr, flags: i32) -> i32 ---
+    @(link_name = "uv_getnameinfo")
+    getnameinfo :: proc(loop: ^loop_t, req: ^getnameinfo_t, getnameinfo_cb_p: getnameinfo_cb, addr: ^posix.sockaddr, flags: i32) -> i32 ---
 
-	@(link_name = "uv_spawn")
-	spawn :: proc(loop: ^uv_loop_t, handle: ^uv_process_t, options: [^]uv_process_options_t) -> i32 ---
+    @(link_name = "uv_spawn")
+    spawn :: proc(loop: ^loop_t, handle: ^process_t, options: [^]process_options_t) -> i32 ---
 
-	@(link_name = "uv_process_kill")
-	process_kill :: proc(param0: ^uv_process_t, signum: i32) -> i32 ---
+    @(link_name = "uv_process_kill")
+    process_kill :: proc(param0: ^process_t, signum: i32) -> i32 ---
 
-	@(link_name = "uv_kill")
-	kill :: proc(pid: i32, signum: i32) -> i32 ---
+    @(link_name = "uv_kill")
+    kill :: proc(pid: i32, signum: i32) -> i32 ---
 
-	@(link_name = "uv_process_get_pid")
-	process_get_pid :: proc(param0: ^uv_process_t) -> uv_pid_t ---
+    @(link_name = "uv_process_get_pid")
+    process_get_pid :: proc(param0: ^process_t) -> pid_t ---
 
-	@(link_name = "uv_queue_work")
-	queue_work :: proc(loop: ^uv_loop_t, req: ^uv_work_t, work_cb: uv_work_cb, after_work_cb: uv_after_work_cb) -> i32 ---
+    @(link_name = "uv_queue_work")
+    queue_work :: proc(loop: ^loop_t, req: ^work_t, work_cb_p: work_cb, after_work_cb_p: after_work_cb) -> i32 ---
 
-	@(link_name = "uv_cancel")
-	cancel :: proc(req: ^uv_req_t) -> i32 ---
+    @(link_name = "uv_cancel")
+    cancel :: proc(req: ^req_t) -> i32 ---
 
-	@(link_name = "uv_setup_args")
-	setup_args :: proc(argc: i32, argv: ^cstring) -> ^cstring ---
+    @(link_name = "uv_setup_args")
+    setup_args :: proc(argc: i32, argv: ^cstring) -> ^cstring ---
 
-	@(link_name = "uv_get_process_title")
-	get_process_title :: proc(buffer: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_get_process_title")
+    get_process_title :: proc(buffer: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_set_process_title")
-	set_process_title :: proc(title: cstring) -> i32 ---
+    @(link_name = "uv_set_process_title")
+    set_process_title :: proc(title: cstring) -> i32 ---
 
-	@(link_name = "uv_resident_set_memory")
-	resident_set_memory :: proc(rss: [^]u64) -> i32 ---
+    @(link_name = "uv_resident_set_memory")
+    resident_set_memory :: proc(rss: [^]u64) -> i32 ---
 
-	@(link_name = "uv_uptime")
-	uptime :: proc(uptime: ^f64) -> i32 ---
+    @(link_name = "uv_uptime")
+    uptime :: proc(uptime: ^f64) -> i32 ---
 
-	@(link_name = "uv_get_osfhandle")
-	get_osfhandle :: proc(fd: i32) -> uv_os_fd_t ---
+    @(link_name = "uv_get_osfhandle")
+    get_osfhandle :: proc(fd: i32) -> os_fd_t ---
 
-	@(link_name = "uv_open_osfhandle")
-	open_osfhandle :: proc(os_fd: uv_os_fd_t) -> i32 ---
+    @(link_name = "uv_open_osfhandle")
+    open_osfhandle :: proc(os_fd: os_fd_t) -> i32 ---
 
-	@(link_name = "uv_getrusage")
-	getrusage :: proc(rusage: ^uv_rusage_t) -> i32 ---
+    @(link_name = "uv_getrusage")
+    getrusage :: proc(rusage: ^rusage_t) -> i32 ---
 
-	@(link_name = "uv_os_homedir")
-	os_homedir :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_homedir")
+    os_homedir :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_tmpdir")
-	os_tmpdir :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_tmpdir")
+    os_tmpdir :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_get_passwd")
-	os_get_passwd :: proc(pwd: ^uv_passwd_t) -> i32 ---
+    @(link_name = "uv_os_get_passwd")
+    os_get_passwd :: proc(pwd: ^passwd_t) -> i32 ---
 
-	@(link_name = "uv_os_free_passwd")
-	os_free_passwd :: proc(pwd: ^uv_passwd_t) ---
+    @(link_name = "uv_os_free_passwd")
+    os_free_passwd :: proc(pwd: ^passwd_t) ---
 
-	@(link_name = "uv_os_get_passwd2")
-	os_get_passwd2 :: proc(pwd: ^uv_passwd_t, uid: uv_uid_t) -> i32 ---
+    @(link_name = "uv_os_get_passwd2")
+    os_get_passwd2 :: proc(pwd: ^passwd_t, uid: uid_t) -> i32 ---
 
-	@(link_name = "uv_os_get_group")
-	os_get_group :: proc(grp: ^uv_group_t, gid: uv_uid_t) -> i32 ---
+    @(link_name = "uv_os_get_group")
+    os_get_group :: proc(grp: ^group_t, gid: uid_t) -> i32 ---
 
-	@(link_name = "uv_os_free_group")
-	os_free_group :: proc(grp: ^uv_group_t) ---
+    @(link_name = "uv_os_free_group")
+    os_free_group :: proc(grp: ^group_t) ---
 
-	@(link_name = "uv_os_getpid")
-	os_getpid :: proc() -> uv_pid_t ---
+    @(link_name = "uv_os_getpid")
+    os_getpid :: proc() -> pid_t ---
 
-	@(link_name = "uv_os_getppid")
-	os_getppid :: proc() -> uv_pid_t ---
+    @(link_name = "uv_os_getppid")
+    os_getppid :: proc() -> pid_t ---
 
-	@(link_name = "uv_os_getpriority")
-	os_getpriority :: proc(pid: uv_pid_t, priority: ^i32) -> i32 ---
+    @(link_name = "uv_os_getpriority")
+    os_getpriority :: proc(pid: pid_t, priority: ^i32) -> i32 ---
 
-	@(link_name = "uv_os_setpriority")
-	os_setpriority :: proc(pid: uv_pid_t, priority: i32) -> i32 ---
+    @(link_name = "uv_os_setpriority")
+    os_setpriority :: proc(pid: pid_t, priority: i32) -> i32 ---
 
-	@(link_name = "uv_thread_getpriority")
-	thread_getpriority :: proc(tid: uv_thread_t, priority: ^i32) -> i32 ---
+    @(link_name = "uv_thread_getpriority")
+    thread_getpriority :: proc(tid: thread_t, priority: ^i32) -> i32 ---
 
-	@(link_name = "uv_thread_setpriority")
-	thread_setpriority :: proc(tid: uv_thread_t, priority: i32) -> i32 ---
+    @(link_name = "uv_thread_setpriority")
+    thread_setpriority :: proc(tid: thread_t, priority: i32) -> i32 ---
 
-	@(link_name = "uv_available_parallelism")
-	available_parallelism :: proc() -> u32 ---
+    @(link_name = "uv_available_parallelism")
+    available_parallelism :: proc() -> u32 ---
 
-	@(link_name = "uv_cpu_info")
-	cpu_info :: proc(cpu_infos: ^[^]uv_cpu_info_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_cpu_info")
+    cpu_info :: proc(cpu_infos: ^[^]cpu_info_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_free_cpu_info")
-	free_cpu_info :: proc(cpu_infos: [^]uv_cpu_info_t, count: i32) ---
+    @(link_name = "uv_free_cpu_info")
+    free_cpu_info :: proc(cpu_infos: [^]cpu_info_t, count: i32) ---
 
-	@(link_name = "uv_cpumask_size")
-	cpumask_size :: proc() -> i32 ---
+    @(link_name = "uv_cpumask_size")
+    cpumask_size :: proc() -> i32 ---
 
-	@(link_name = "uv_interface_addresses")
-	interface_addresses :: proc(addresses: ^[^]uv_interface_address_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_interface_addresses")
+    interface_addresses :: proc(addresses: ^[^]interface_address_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_free_interface_addresses")
-	free_interface_addresses :: proc(addresses: [^]uv_interface_address_t, count: i32) ---
+    @(link_name = "uv_free_interface_addresses")
+    free_interface_addresses :: proc(addresses: [^]interface_address_t, count: i32) ---
 
-	@(link_name = "uv_os_environ")
-	os_environ :: proc(envitems: ^[^]uv_env_item_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_os_environ")
+    os_environ :: proc(envitems: ^[^]env_item_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_os_free_environ")
-	os_free_environ :: proc(envitems: [^]uv_env_item_t, count: i32) ---
+    @(link_name = "uv_os_free_environ")
+    os_free_environ :: proc(envitems: [^]env_item_t, count: i32) ---
 
-	@(link_name = "uv_os_getenv")
-	os_getenv :: proc(name: cstring, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_getenv")
+    os_getenv :: proc(name: cstring, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_setenv")
-	os_setenv :: proc(name: cstring, value: cstring) -> i32 ---
+    @(link_name = "uv_os_setenv")
+    os_setenv :: proc(name: cstring, value: cstring) -> i32 ---
 
-	@(link_name = "uv_os_unsetenv")
-	os_unsetenv :: proc(name: cstring) -> i32 ---
+    @(link_name = "uv_os_unsetenv")
+    os_unsetenv :: proc(name: cstring) -> i32 ---
 
-	@(link_name = "uv_os_gethostname")
-	os_gethostname :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_gethostname")
+    os_gethostname :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_uname")
-	os_uname :: proc(buffer: ^uv_utsname_t) -> i32 ---
+    @(link_name = "uv_os_uname")
+    os_uname :: proc(buffer: ^utsname_t) -> i32 ---
 
-	@(link_name = "uv_metrics_info")
-	metrics_info :: proc(loop: ^uv_loop_t, metrics: [^]uv_metrics_t) -> i32 ---
+    @(link_name = "uv_metrics_info")
+    metrics_info :: proc(loop: ^loop_t, metrics: [^]metrics_t) -> i32 ---
 
-	@(link_name = "uv_metrics_idle_time")
-	metrics_idle_time :: proc(loop: ^uv_loop_t) -> u64 ---
+    @(link_name = "uv_metrics_idle_time")
+    metrics_idle_time :: proc(loop: ^loop_t) -> u64 ---
 
-	@(link_name = "uv_fs_get_type")
-	fs_get_type :: proc(param0: ^uv_fs_t) -> uv_fs_type ---
+    @(link_name = "uv_fs_get_type")
+    fs_get_type :: proc(param0: ^fs_t) -> fs_type ---
 
-	@(link_name = "uv_fs_get_result")
-	fs_get_result :: proc(param0: ^uv_fs_t) -> i32 ---
+    @(link_name = "uv_fs_get_result")
+    fs_get_result :: proc(param0: ^fs_t) -> i64 ---
 
-	@(link_name = "uv_fs_get_system_error")
-	fs_get_system_error :: proc(param0: ^uv_fs_t) -> i32 ---
+    @(link_name = "uv_fs_get_system_error")
+    fs_get_system_error :: proc(param0: ^fs_t) -> i32 ---
 
-	@(link_name = "uv_fs_get_ptr")
-	fs_get_ptr :: proc(param0: ^uv_fs_t) -> rawptr ---
+    @(link_name = "uv_fs_get_ptr")
+    fs_get_ptr :: proc(param0: ^fs_t) -> rawptr ---
 
-	@(link_name = "uv_fs_get_path")
-	fs_get_path :: proc(param0: ^uv_fs_t) -> cstring ---
+    @(link_name = "uv_fs_get_path")
+    fs_get_path :: proc(param0: ^fs_t) -> cstring ---
 
-	@(link_name = "uv_fs_get_statbuf")
-	fs_get_statbuf :: proc(param0: ^uv_fs_t) -> ^uv_stat_t ---
+    @(link_name = "uv_fs_get_statbuf")
+    fs_get_statbuf :: proc(param0: ^fs_t) -> ^stat_t ---
 
-	@(link_name = "uv_fs_req_cleanup")
-	fs_req_cleanup :: proc(req: ^uv_fs_t) ---
+    @(link_name = "uv_fs_req_cleanup")
+    fs_req_cleanup :: proc(req: ^fs_t) ---
 
-	@(link_name = "uv_fs_close")
-	fs_close :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_close")
+    fs_close :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_open")
-	fs_open :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, flags: i32, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_open")
+    fs_open :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, flags: i32, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_read")
-	fs_read :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, bufs: [^]uv_buf_t, nbufs: u32, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_read")
+    fs_read :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, bufs: [^]buf_t, nbufs: u32, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_unlink")
-	fs_unlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_unlink")
+    fs_unlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_write")
-	fs_write :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, bufs: [^]uv_buf_t, nbufs: u32, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_write")
+    fs_write :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, bufs: [^]buf_t, nbufs: u32, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_copyfile")
-	fs_copyfile :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_copyfile")
+    fs_copyfile :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkdir")
-	fs_mkdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkdir")
+    fs_mkdir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkdtemp")
-	fs_mkdtemp :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, tpl: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkdtemp")
+    fs_mkdtemp :: proc(loop: ^loop_t, req: ^fs_t, tpl: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkstemp")
-	fs_mkstemp :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, tpl: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkstemp")
+    fs_mkstemp :: proc(loop: ^loop_t, req: ^fs_t, tpl: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_rmdir")
-	fs_rmdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_rmdir")
+    fs_rmdir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_scandir")
-	fs_scandir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_scandir")
+    fs_scandir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_scandir_next")
-	fs_scandir_next :: proc(req: ^uv_fs_t, ent: ^uv_dirent_t) -> i32 ---
+    @(link_name = "uv_fs_scandir_next")
+    fs_scandir_next :: proc(req: ^fs_t, ent: ^dirent_t) -> i32 ---
 
-	@(link_name = "uv_fs_opendir")
-	fs_opendir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_opendir")
+    fs_opendir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_readdir")
-	fs_readdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, dir: ^uv_dir_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_readdir")
+    fs_readdir :: proc(loop: ^loop_t, req: ^fs_t, dir: ^dir_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_closedir")
-	fs_closedir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, dir: ^uv_dir_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_closedir")
+    fs_closedir :: proc(loop: ^loop_t, req: ^fs_t, dir: ^dir_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_stat")
-	fs_stat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_stat")
+    fs_stat :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fstat")
-	fs_fstat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fstat")
+    fs_fstat :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_rename")
-	fs_rename :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_rename")
+    fs_rename :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fsync")
-	fs_fsync :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fsync")
+    fs_fsync :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fdatasync")
-	fs_fdatasync :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fdatasync")
+    fs_fdatasync :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_ftruncate")
-	fs_ftruncate :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_ftruncate")
+    fs_ftruncate :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_sendfile")
-	fs_sendfile :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, out_fd: uv_file, in_fd: uv_file, in_offset: i64, length: u64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_sendfile")
+    fs_sendfile :: proc(loop: ^loop_t, req: ^fs_t, out_fd: file, in_fd: file, in_offset: i64, length: u64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_access")
-	fs_access :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_access")
+    fs_access :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_chmod")
-	fs_chmod :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_chmod")
+    fs_chmod :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_utime")
-	fs_utime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_utime")
+    fs_utime :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_futime")
-	fs_futime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_futime")
+    fs_futime :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lutime")
-	fs_lutime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lutime")
+    fs_lutime :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lstat")
-	fs_lstat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lstat")
+    fs_lstat :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_link")
-	fs_link :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_link")
+    fs_link :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_symlink")
-	fs_symlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_symlink")
+    fs_symlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_readlink")
-	fs_readlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_readlink")
+    fs_readlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_realpath")
-	fs_realpath :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_realpath")
+    fs_realpath :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fchmod")
-	fs_fchmod :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fchmod")
+    fs_fchmod :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_chown")
-	fs_chown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_chown")
+    fs_chown :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fchown")
-	fs_fchown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fchown")
+    fs_fchown :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lchown")
-	fs_lchown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lchown")
+    fs_lchown :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_statfs")
-	fs_statfs :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_statfs")
+    fs_statfs :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_poll_init")
-	fs_poll_init :: proc(loop: ^uv_loop_t, handle: ^uv_fs_poll_t) -> i32 ---
+    @(link_name = "uv_fs_poll_init")
+    fs_poll_init :: proc(loop: ^loop_t, handle: ^fs_poll_t) -> i32 ---
 
-	@(link_name = "uv_fs_poll_start")
-	fs_poll_start :: proc(handle: ^uv_fs_poll_t, poll_cb: uv_fs_poll_cb, path: cstring, interval: u32) -> i32 ---
+    @(link_name = "uv_fs_poll_start")
+    fs_poll_start :: proc(handle: ^fs_poll_t, poll_cb_p: fs_poll_cb, path: cstring, interval: u32) -> i32 ---
 
-	@(link_name = "uv_fs_poll_stop")
-	fs_poll_stop :: proc(handle: ^uv_fs_poll_t) -> i32 ---
+    @(link_name = "uv_fs_poll_stop")
+    fs_poll_stop :: proc(handle: ^fs_poll_t) -> i32 ---
 
-	@(link_name = "uv_fs_poll_getpath")
-	fs_poll_getpath :: proc(handle: ^uv_fs_poll_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_fs_poll_getpath")
+    fs_poll_getpath :: proc(handle: ^fs_poll_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_signal_init")
-	signal_init :: proc(loop: ^uv_loop_t, handle: ^uv_signal_t) -> i32 ---
+    @(link_name = "uv_signal_init")
+    signal_init :: proc(loop: ^loop_t, handle: ^signal_t) -> i32 ---
 
-	@(link_name = "uv_signal_start")
-	signal_start :: proc(handle: ^uv_signal_t, signal_cb: uv_signal_cb, signum: i32) -> i32 ---
+    @(link_name = "uv_signal_start")
+    signal_start :: proc(handle: ^signal_t, signal_cb_p: signal_cb, signum: i32) -> i32 ---
 
-	@(link_name = "uv_signal_start_oneshot")
-	signal_start_oneshot :: proc(handle: ^uv_signal_t, signal_cb: uv_signal_cb, signum: i32) -> i32 ---
+    @(link_name = "uv_signal_start_oneshot")
+    signal_start_oneshot :: proc(handle: ^signal_t, signal_cb_p: signal_cb, signum: i32) -> i32 ---
 
-	@(link_name = "uv_signal_stop")
-	signal_stop :: proc(handle: ^uv_signal_t) -> i32 ---
+    @(link_name = "uv_signal_stop")
+    signal_stop :: proc(handle: ^signal_t) -> i32 ---
 
-	@(link_name = "uv_loadavg")
-	loadavg :: proc(avg: [3]f64) ---
+    @(link_name = "uv_loadavg")
+    loadavg :: proc(avg: [3]f64) ---
 
-	@(link_name = "uv_fs_event_init")
-	fs_event_init :: proc(loop: ^uv_loop_t, handle: ^uv_fs_event_t) -> i32 ---
+    @(link_name = "uv_fs_event_init")
+    fs_event_init :: proc(loop: ^loop_t, handle: ^fs_event_t) -> i32 ---
 
-	@(link_name = "uv_fs_event_start")
-	fs_event_start :: proc(handle: ^uv_fs_event_t, cb: uv_fs_event_cb, path: cstring, flags: u32) -> i32 ---
+    @(link_name = "uv_fs_event_start")
+    fs_event_start :: proc(handle: ^fs_event_t, cb: fs_event_cb, path: cstring, flags: u32) -> i32 ---
 
-	@(link_name = "uv_fs_event_stop")
-	fs_event_stop :: proc(handle: ^uv_fs_event_t) -> i32 ---
+    @(link_name = "uv_fs_event_stop")
+    fs_event_stop :: proc(handle: ^fs_event_t) -> i32 ---
 
-	@(link_name = "uv_fs_event_getpath")
-	fs_event_getpath :: proc(handle: ^uv_fs_event_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_fs_event_getpath")
+    fs_event_getpath :: proc(handle: ^fs_event_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_ip4_addr")
-	ip4_addr :: proc(ip: cstring, port: i32, addr: ^sockaddr_in) -> i32 ---
+    @(link_name = "uv_ip4_addr")
+    ip4_addr :: proc(ip: cstring, port: i32, addr: ^posix.sockaddr_in) -> i32 ---
 
-	@(link_name = "uv_ip6_addr")
-	ip6_addr :: proc(ip: cstring, port: i32, addr: ^sockaddr_in6) -> i32 ---
+    @(link_name = "uv_ip6_addr")
+    ip6_addr :: proc(ip: cstring, port: i32, addr: ^posix.sockaddr_in6) -> i32 ---
 
-	@(link_name = "uv_ip4_name")
-	ip4_name :: proc(src: ^sockaddr_in, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_ip4_name")
+    ip4_name :: proc(src: ^posix.sockaddr_in, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_ip6_name")
-	ip6_name :: proc(src: ^sockaddr_in6, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_ip6_name")
+    ip6_name :: proc(src: ^posix.sockaddr_in6, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_ip_name")
-	ip_name :: proc(src: ^sockaddr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_ip_name")
+    ip_name :: proc(src: ^posix.sockaddr, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_inet_ntop")
-	inet_ntop :: proc(af: i32, src: rawptr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_inet_ntop")
+    inet_ntop :: proc(af: i32, src: rawptr, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_inet_pton")
-	inet_pton :: proc(af: i32, src: cstring, dst: rawptr) -> i32 ---
+    @(link_name = "uv_inet_pton")
+    inet_pton :: proc(af: i32, src: cstring, dst: rawptr) -> i32 ---
 
-	@(link_name = "uv_random")
-	random :: proc(loop: ^uv_loop_t, req: ^uv_random_t, buf: rawptr, buflen: u64, flags: u32, cb: uv_random_cb) -> i32 ---
+    @(link_name = "uv_random")
+    random :: proc(loop: ^loop_t, req: ^random_t, buf: rawptr, buflen: u64, flags: u32, cb: random_cb) -> i32 ---
 
-	@(link_name = "uv_if_indextoname")
-	if_indextoname :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_if_indextoname")
+    if_indextoname :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_if_indextoiid")
-	if_indextoiid :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_if_indextoiid")
+    if_indextoiid :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_exepath")
-	exepath :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_exepath")
+    exepath :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_cwd")
-	cwd :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_cwd")
+    cwd :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_chdir")
-	chdir :: proc(dir: cstring) -> i32 ---
+    @(link_name = "uv_chdir")
+    chdir :: proc(dir: cstring) -> i32 ---
 
-	@(link_name = "uv_get_free_memory")
-	get_free_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_free_memory")
+    get_free_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_total_memory")
-	get_total_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_total_memory")
+    get_total_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_constrained_memory")
-	get_constrained_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_constrained_memory")
+    get_constrained_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_available_memory")
-	get_available_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_available_memory")
+    get_available_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_clock_gettime")
-	clock_gettime :: proc(clock_id: uv_clock_id, ts: [^]uv_timespec64_t) -> i32 ---
+    @(link_name = "uv_clock_gettime")
+    clock_gettime :: proc(clock_id_p: clock_id, ts: [^]timespec64_t) -> i32 ---
 
-	@(link_name = "uv_hrtime")
-	hrtime :: proc() -> u64 ---
+    @(link_name = "uv_hrtime")
+    hrtime :: proc() -> u64 ---
 
-	@(link_name = "uv_sleep")
-	sleep :: proc(msec: u32) ---
+    @(link_name = "uv_sleep")
+    sleep :: proc(msec: u32) ---
 
-	@(link_name = "uv_disable_stdio_inheritance")
-	disable_stdio_inheritance :: proc() ---
+    @(link_name = "uv_disable_stdio_inheritance")
+    disable_stdio_inheritance :: proc() ---
 
-	@(link_name = "uv_dlopen")
-	dlopen :: proc(filename: cstring, lib: ^uv_lib_t) -> i32 ---
+    @(link_name = "uv_dlopen")
+    dlopen :: proc(filename: cstring, lib: ^lib_t) -> i32 ---
 
-	@(link_name = "uv_dlclose")
-	dlclose :: proc(lib: ^uv_lib_t) ---
+    @(link_name = "uv_dlclose")
+    dlclose :: proc(lib: ^lib_t) ---
 
-	@(link_name = "uv_dlsym")
-	dlsym :: proc(lib: ^uv_lib_t, name: cstring, ptr: ^rawptr) -> i32 ---
+    @(link_name = "uv_dlsym")
+    dlsym :: proc(lib: ^lib_t, name: cstring, ptr: ^rawptr) -> i32 ---
 
-	@(link_name = "uv_dlerror")
-	dlerror :: proc(lib: ^uv_lib_t) -> cstring ---
+    @(link_name = "uv_dlerror")
+    dlerror :: proc(lib: ^lib_t) -> cstring ---
 
-	@(link_name = "uv_mutex_init")
-	mutex_init :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_init")
+    mutex_init :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_init_recursive")
-	mutex_init_recursive :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_init_recursive")
+    mutex_init_recursive :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_destroy")
-	mutex_destroy :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_mutex_destroy")
+    mutex_destroy :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_mutex_lock")
-	mutex_lock :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_mutex_lock")
+    mutex_lock :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_mutex_trylock")
-	mutex_trylock :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_trylock")
+    mutex_trylock :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_unlock")
-	mutex_unlock :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_mutex_unlock")
+    mutex_unlock :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_rwlock_init")
-	rwlock_init :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_init")
+    rwlock_init :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_destroy")
-	rwlock_destroy :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_destroy")
+    rwlock_destroy :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_rdlock")
-	rwlock_rdlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_rdlock")
+    rwlock_rdlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_tryrdlock")
-	rwlock_tryrdlock :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_tryrdlock")
+    rwlock_tryrdlock :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_rdunlock")
-	rwlock_rdunlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_rdunlock")
+    rwlock_rdunlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_wrlock")
-	rwlock_wrlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_wrlock")
+    rwlock_wrlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_trywrlock")
-	rwlock_trywrlock :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_trywrlock")
+    rwlock_trywrlock :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_wrunlock")
-	rwlock_wrunlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_wrunlock")
+    rwlock_wrunlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_sem_init")
-	sem_init :: proc(sem: ^uv_sem_t, value: u32) -> i32 ---
+    @(link_name = "uv_sem_init")
+    sem_init :: proc(sem: ^sem_t, value: u32) -> i32 ---
 
-	@(link_name = "uv_sem_destroy")
-	sem_destroy :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_destroy")
+    sem_destroy :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_post")
-	sem_post :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_post")
+    sem_post :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_wait")
-	sem_wait :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_wait")
+    sem_wait :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_trywait")
-	sem_trywait :: proc(sem: ^uv_sem_t) -> i32 ---
+    @(link_name = "uv_sem_trywait")
+    sem_trywait :: proc(sem: ^sem_t) -> i32 ---
 
-	@(link_name = "uv_cond_init")
-	cond_init :: proc(cond: ^uv_cond_t) -> i32 ---
+    @(link_name = "uv_cond_init")
+    cond_init :: proc(cond: ^cond_t) -> i32 ---
 
-	@(link_name = "uv_cond_destroy")
-	cond_destroy :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_cond_destroy")
+    cond_destroy :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_cond_signal")
-	cond_signal :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_cond_signal")
+    cond_signal :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_cond_broadcast")
-	cond_broadcast :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_cond_broadcast")
+    cond_broadcast :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_barrier_init")
-	barrier_init :: proc(barrier: ^uv_barrier_t, count: u32) -> i32 ---
+    @(link_name = "uv_barrier_init")
+    barrier_init :: proc(barrier: ^barrier_t, count: u32) -> i32 ---
 
-	@(link_name = "uv_barrier_destroy")
-	barrier_destroy :: proc(barrier: ^uv_barrier_t) ---
+    @(link_name = "uv_barrier_destroy")
+    barrier_destroy :: proc(barrier: ^barrier_t) ---
 
-	@(link_name = "uv_barrier_wait")
-	barrier_wait :: proc(barrier: ^uv_barrier_t) -> i32 ---
+    @(link_name = "uv_barrier_wait")
+    barrier_wait :: proc(barrier: ^barrier_t) -> i32 ---
 
-	@(link_name = "uv_cond_wait")
-	cond_wait :: proc(cond: ^uv_cond_t, mutex: ^uv_mutex_t) ---
+    @(link_name = "uv_cond_wait")
+    cond_wait :: proc(cond: ^cond_t, mutex: ^mutex_t) ---
 
-	@(link_name = "uv_cond_timedwait")
-	cond_timedwait :: proc(cond: ^uv_cond_t, mutex: ^uv_mutex_t, timeout: u64) -> i32 ---
+    @(link_name = "uv_cond_timedwait")
+    cond_timedwait :: proc(cond: ^cond_t, mutex: ^mutex_t, timeout: u64) -> i32 ---
 
-	@(link_name = "uv_once")
-	once :: proc(guard: ^uv_once_t, callback: callback_func_ptr_anon_21) ---
+    @(link_name = "uv_once")
+    once :: proc(guard: rawptr, callback: callback_func_ptr_anon_21) ---
 
-	@(link_name = "uv_key_create")
-	key_create :: proc(key: ^uv_key_t) -> i32 ---
+    @(link_name = "uv_key_create")
+    key_create :: proc(key: ^key_t) -> i32 ---
 
-	@(link_name = "uv_key_delete")
-	key_delete :: proc(key: ^uv_key_t) ---
+    @(link_name = "uv_key_delete")
+    key_delete :: proc(key: ^key_t) ---
 
-	@(link_name = "uv_key_get")
-	key_get :: proc(key: ^uv_key_t) -> rawptr ---
+    @(link_name = "uv_key_get")
+    key_get :: proc(key: ^key_t) -> rawptr ---
 
-	@(link_name = "uv_key_set")
-	key_set :: proc(key: ^uv_key_t, value: rawptr) ---
+    @(link_name = "uv_key_set")
+    key_set :: proc(key: ^key_t, value: rawptr) ---
 
-	@(link_name = "uv_gettimeofday")
-	gettimeofday :: proc(tv: ^uv_timeval64_t) -> i32 ---
+    @(link_name = "uv_gettimeofday")
+    gettimeofday :: proc(tv: ^timeval64_t) -> i32 ---
 
-	@(link_name = "uv_thread_create")
-	thread_create :: proc(tid: ^uv_thread_t, entry: uv_thread_cb, arg: rawptr) -> i32 ---
+    @(link_name = "uv_thread_create")
+    thread_create :: proc(tid: ^thread_t, entry: thread_cb, arg: rawptr) -> i32 ---
 
-	@(link_name = "uv_thread_create_ex")
-	thread_create_ex :: proc(tid: ^uv_thread_t, params: [^]uv_thread_options_t, entry: uv_thread_cb, arg: rawptr) -> i32 ---
+    @(link_name = "uv_thread_create_ex")
+    thread_create_ex :: proc(tid: ^thread_t, params: [^]thread_options_t, entry: thread_cb, arg: rawptr) -> i32 ---
 
-	@(link_name = "uv_thread_setaffinity")
-	thread_setaffinity :: proc(tid: ^uv_thread_t, cpumask: cstring, oldmask: cstring, mask_size: u64) -> i32 ---
+    @(link_name = "uv_thread_setaffinity")
+    thread_setaffinity :: proc(tid: ^thread_t, cpumask: cstring, oldmask: cstring, mask_size: u64) -> i32 ---
 
-	@(link_name = "uv_thread_getaffinity")
-	thread_getaffinity :: proc(tid: ^uv_thread_t, cpumask: cstring, mask_size: u64) -> i32 ---
+    @(link_name = "uv_thread_getaffinity")
+    thread_getaffinity :: proc(tid: ^thread_t, cpumask: cstring, mask_size: u64) -> i32 ---
 
-	@(link_name = "uv_thread_getcpu")
-	thread_getcpu :: proc() -> i32 ---
+    @(link_name = "uv_thread_getcpu")
+    thread_getcpu :: proc() -> i32 ---
 
-	@(link_name = "uv_thread_self")
-	thread_self :: proc() -> uv_thread_t ---
+    @(link_name = "uv_thread_self")
+    thread_self :: proc() -> thread_t ---
 
-	@(link_name = "uv_thread_join")
-	thread_join :: proc(tid: ^uv_thread_t) -> i32 ---
+    @(link_name = "uv_thread_join")
+    thread_join :: proc(tid: ^thread_t) -> i32 ---
 
-	@(link_name = "uv_thread_equal")
-	thread_equal :: proc(t1: ^uv_thread_t, t2: ^uv_thread_t) -> i32 ---
+    @(link_name = "uv_thread_equal")
+    thread_equal :: proc(t1: ^thread_t, t2: ^thread_t) -> i32 ---
 
-	@(link_name = "uv_loop_get_data")
-	loop_get_data :: proc(param0: ^uv_loop_t) -> rawptr ---
+    @(link_name = "uv_loop_get_data")
+    loop_get_data :: proc(param0: ^loop_t) -> rawptr ---
 
-	@(link_name = "uv_loop_set_data")
-	loop_set_data :: proc(param0: ^uv_loop_t, data: rawptr) ---
+    @(link_name = "uv_loop_set_data")
+    loop_set_data :: proc(param0: ^loop_t, data: rawptr) ---
 
-	@(link_name = "uv_utf16_length_as_wtf8")
-	utf16_length_as_wtf8 :: proc(invalid_procedure: ^^^rawptr, error_while_generating_procedure: ^^^^rawptr) ---
+    @(link_name = "uv_utf16_length_as_wtf8")
+    utf16_length_as_wtf8 :: proc(utf16: ^u16, utf16_len: i64) -> u64 ---
 
-	@(link_name = "uv_utf16_to_wtf8")
-	utf16_to_wtf8 :: proc(invalid_procedure: ^^^rawptr, error_while_generating_procedure: ^^^^rawptr) ---
+    @(link_name = "uv_utf16_to_wtf8")
+    utf16_to_wtf8 :: proc(utf16: ^u16, utf16_len: i64, wtf8_ptr: ^cstring, wtf8_len_ptr: ^u64) -> i32 ---
 
-	@(link_name = "uv_wtf8_length_as_utf16")
-	wtf8_length_as_utf16 :: proc(wtf8: cstring) -> i32 ---
+    @(link_name = "uv_wtf8_length_as_utf16")
+    wtf8_length_as_utf16 :: proc(wtf8: cstring) -> i64 ---
 
-	@(link_name = "uv_wtf8_to_utf16")
-	wtf8_to_utf16 :: proc(wtf8: cstring, utf16: ^u16, utf16_len: u64) ---
+    @(link_name = "uv_wtf8_to_utf16")
+    wtf8_to_utf16 :: proc(wtf8: cstring, utf16: ^u16, utf16_len: u64) ---
 
 }
+

--- a/tutorial/1-basics_of_libuv/helloworld/main.odin
+++ b/tutorial/1-basics_of_libuv/helloworld/main.odin
@@ -6,13 +6,13 @@ import uv "../../../"
 import "core:fmt"
 
 main :: proc() {
-	loop := new(uv.uv_loop_t)
+	loop := new(uv.loop_t)
 
 	uv.loop_init(loop)
 
 	fmt.println("Now quiting")
 
-	uv.run(loop, uv.uv_run_mode.RUN_DEFAULT)
+	uv.run(loop, .RUN_DEFAULT)
 
 	uv.loop_close(loop)
 

--- a/tutorial/1-basics_of_libuv/idling/main.odin
+++ b/tutorial/1-basics_of_libuv/idling/main.odin
@@ -5,7 +5,7 @@ import "core:fmt"
 
 counter: i64 = 0
 
-wait_for_a_while :: proc "c" (handle: ^uv.uv_idle_t) {
+wait_for_a_while :: proc "c" (handle: ^uv.idle_t) {
 	counter += 1
 	if counter >= 10e6 {
 		uv.idle_stop(handle)
@@ -15,7 +15,7 @@ wait_for_a_while :: proc "c" (handle: ^uv.uv_idle_t) {
 
 main :: proc() {
 	loop := uv.default_loop()
-	idler: uv.uv_idle_t
+	idler: uv.idle_t
 
 	uv.idle_init(loop, &idler)
 	uv.idle_start(&idler, wait_for_a_while)

--- a/tutorial/2-filesystem/uvcat/main.odin
+++ b/tutorial/2-filesystem/uvcat/main.odin
@@ -8,19 +8,19 @@ import "core:os"
 import "core:strings"
 
 
-open_req: uv.uv_fs_t
-read_req: uv.uv_fs_t
-write_req: uv.uv_fs_t
+open_req: uv.fs_t
+read_req: uv.fs_t
+write_req: uv.fs_t
 
-iov: uv.uv_buf_t
+iov: uv.buf_t
 buffer: [1024]c.char
 
-on_read :: proc "c" (req: ^uv.uv_fs_t) {
+on_read :: proc "c" (req: ^uv.fs_t) {
 	context = runtime.default_context()
 	if req.result < 0 {
 		fmt.println("Error read error: ", uv.strerror(cast(i32)req.result))
 	} else if (req.result == 0) {
-		close_req: uv.uv_fs_t
+		close_req: uv.fs_t
 		uv.fs_close(uv.default_loop(), &close_req, cast(i32)open_req.result, nil)
 	} else if (req.result > 0) {
 		iov.len = cast(u64)req.result
@@ -28,7 +28,7 @@ on_read :: proc "c" (req: ^uv.uv_fs_t) {
 	}
 }
 
-on_write :: proc "c" (req: ^uv.uv_fs_t) {
+on_write :: proc "c" (req: ^uv.fs_t) {
 	context = runtime.default_context()
 	if req.result < 0 {
 		fmt.println("Error write error: ", uv.strerror(cast(i32)req.result))
@@ -37,7 +37,7 @@ on_write :: proc "c" (req: ^uv.uv_fs_t) {
 	}
 }
 
-on_open :: proc "c" (req: ^uv.uv_fs_t) {
+on_open :: proc "c" (req: ^uv.fs_t) {
 	context = runtime.default_context()
 	assert(req == &open_req)
 	if req.result >= 0 {

--- a/uv.odin
+++ b/uv.odin
@@ -1,2879 +1,1673 @@
 package uv
 
-ptrdiff_t :: i64
-size_t :: u64
-wchar_t :: i32
-max_align_t :: struct {
-	__max_align_ll: i64,
-	__max_align_ld: [16]byte,
-}
-__u_char :: u8
-__u_short :: u16
-__u_int :: u32
-__u_long :: u64
-__int8_t :: i8
-__uint8_t :: u8
-__int16_t :: i16
-__uint16_t :: u16
-__int32_t :: i32
-__uint32_t :: u32
-__int64_t :: i64
-__uint64_t :: u64
-__int_least8_t :: __int8_t
-__uint_least8_t :: __uint8_t
-__int_least16_t :: __int16_t
-__uint_least16_t :: __uint16_t
-__int_least32_t :: __int32_t
-__uint_least32_t :: __uint32_t
-__int_least64_t :: __int64_t
-__uint_least64_t :: __uint64_t
-__quad_t :: i64
-__u_quad_t :: u64
-__intmax_t :: i64
-__uintmax_t :: u64
-__dev_t :: u64
-__uid_t :: u32
-__gid_t :: u32
-__ino_t :: u64
-__ino64_t :: u64
-__mode_t :: u32
-__nlink_t :: u64
-__off_t :: i64
-__off64_t :: i64
-__pid_t :: i32
-__fsid_t :: struct {
-	__val: [2]i32,
-}
-__clock_t :: i64
-__rlim_t :: u64
-__rlim64_t :: u64
-__id_t :: u32
-__time_t :: i64
-__useconds_t :: u32
-__suseconds_t :: i64
-__suseconds64_t :: i64
-__daddr_t :: i32
-__key_t :: i32
-__clockid_t :: i32
-__timer_t :: rawptr
-__blksize_t :: i64
-__blkcnt_t :: i64
-__blkcnt64_t :: i64
-__fsblkcnt_t :: u64
-__fsblkcnt64_t :: u64
-__fsfilcnt_t :: u64
-__fsfilcnt64_t :: u64
-__fsword_t :: i64
-__ssize_t :: i64
-__syscall_slong_t :: i64
-__syscall_ulong_t :: u64
-__loff_t :: __off64_t
-__caddr_t :: cstring
-__intptr_t :: i64
-__socklen_t :: u32
-__sig_atomic_t :: i32
-__value_union_anon_0 :: struct #raw_union {
-	__wch:  u32,
-	__wchb: [4]i8,
-}
-__mbstate_t :: struct {
-	__count: i32,
-	__value: __value_union_anon_0,
-}
-_G_fpos_t :: struct {
-	__pos:   __off_t,
-	__state: __mbstate_t,
-}
-__fpos_t :: _G_fpos_t
-_G_fpos64_t :: struct {
-	__pos:   __off64_t,
-	__state: __mbstate_t,
-}
-__fpos64_t :: _G_fpos64_t
-_IO_marker :: ^^^rawptr
-_IO_lock_t :: ^^^rawptr
-_IO_codecvt :: ^^^rawptr
-_IO_wide_data :: ^^^rawptr
-_IO_FILE :: struct {
-	_flags:          i32,
-	_IO_read_ptr:    cstring,
-	_IO_read_end:    cstring,
-	_IO_read_base:   cstring,
-	_IO_write_base:  cstring,
-	_IO_write_ptr:   cstring,
-	_IO_write_end:   cstring,
-	_IO_buf_base:    cstring,
-	_IO_buf_end:     cstring,
-	_IO_save_base:   cstring,
-	_IO_backup_base: cstring,
-	_IO_save_end:    cstring,
-	_markers:        [^]_IO_marker,
-	_chain:          ^_IO_FILE,
-	_fileno:         i32,
-	_flags2:         i32,
-	_old_offset:     __off_t,
-	_cur_column:     u16,
-	_vtable_offset:  i8,
-	_shortbuf:       [1]i8,
-	_lock:           ^_IO_lock_t,
-	_offset:         __off64_t,
-	_codecvt:        ^_IO_codecvt,
-	_wide_data:      ^_IO_wide_data,
-	_freeres_list:   ^_IO_FILE,
-	_freeres_buf:    rawptr,
-	__pad5:          u64,
-	_mode:           i32,
-	_unused2:        [20]i8,
-}
-__FILE :: _IO_FILE
-FILE :: _IO_FILE
-cookie_read_function_t :: #type proc "c" (
-	__cookie: rawptr,
-	__buf: cstring,
-	__nbytes: u64,
-) -> __ssize_t
-cookie_write_function_t :: #type proc "c" (
-	__cookie: rawptr,
-	__buf: cstring,
-	__nbytes: u64,
-) -> __ssize_t
-cookie_seek_function_t :: #type proc "c" (__cookie: rawptr, __pos: [^]__off64_t, __w: i32) -> i32
-cookie_close_function_t :: #type proc "c" (__cookie: rawptr) -> i32
-_IO_cookie_io_functions_t :: struct {
-	read:  ^cookie_read_function_t,
-	write: ^cookie_write_function_t,
-	seek:  ^cookie_seek_function_t,
-	close: ^cookie_close_function_t,
-}
-cookie_io_functions_t :: _IO_cookie_io_functions_t
-off_t :: __off_t
-ssize_t :: __ssize_t
-fpos_t :: __fpos_t
-int8_t :: __int8_t
-int16_t :: __int16_t
-int32_t :: __int32_t
-int64_t :: __int64_t
-uint8_t :: __uint8_t
-uint16_t :: __uint16_t
-uint32_t :: __uint32_t
-uint64_t :: __uint64_t
-int_least8_t :: __int_least8_t
-int_least16_t :: __int_least16_t
-int_least32_t :: __int_least32_t
-int_least64_t :: __int_least64_t
-uint_least8_t :: __uint_least8_t
-uint_least16_t :: __uint_least16_t
-uint_least32_t :: __uint_least32_t
-uint_least64_t :: __uint_least64_t
-int_fast8_t :: i8
-int_fast16_t :: i64
-int_fast32_t :: i64
-int_fast64_t :: i64
-uint_fast8_t :: u8
-uint_fast16_t :: u64
-uint_fast32_t :: u64
-uint_fast64_t :: u64
-intptr_t :: i64
-uintptr_t :: u64
-intmax_t :: __intmax_t
-uintmax_t :: __uintmax_t
-uv__queue :: struct {
-	next: ^uv__queue,
-	prev: ^uv__queue,
-}
-u_char :: __u_char
-u_short :: __u_short
-u_int :: __u_int
-u_long :: __u_long
-quad_t :: __quad_t
-u_quad_t :: __u_quad_t
-fsid_t :: __fsid_t
-loff_t :: __loff_t
-ino_t :: __ino_t
-dev_t :: __dev_t
-gid_t :: __gid_t
-mode_t :: __mode_t
-nlink_t :: __nlink_t
-uid_t :: __uid_t
-pid_t :: __pid_t
-id_t :: __id_t
-daddr_t :: __daddr_t
-caddr_t :: __caddr_t
-key_t :: __key_t
-clock_t :: __clock_t
-clockid_t :: __clockid_t
-time_t :: __time_t
-timer_t :: __timer_t
-ulong :: u64
-ushort :: u16
-uint_ :: u32
-u_int8_t :: __uint8_t
-u_int16_t :: __uint16_t
-u_int32_t :: __uint32_t
-u_int64_t :: __uint64_t
-register_t :: i64
-__sigset_t :: struct {
-	__val: [16]u64,
-}
-sigset_t :: __sigset_t
-timeval :: struct {
-	tv_sec:  __time_t,
-	tv_usec: __suseconds_t,
-}
-timespec :: struct {
-	tv_sec:  __time_t,
-	tv_nsec: __syscall_slong_t,
-}
-suseconds_t :: __suseconds_t
-__fd_mask :: i64
-fd_set :: struct {
-	__fds_bits: [16]__fd_mask,
-}
-fd_mask :: __fd_mask
-blksize_t :: __blksize_t
-blkcnt_t :: __blkcnt_t
-fsblkcnt_t :: __fsblkcnt_t
-fsfilcnt_t :: __fsfilcnt_t
-__value32_struct_anon_1 :: struct {
-	__low:  u32,
-	__high: u32,
-}
-__atomic_wide_counter :: struct #raw_union {
-	__value64: u64,
-	__value32: __value32_struct_anon_1,
-}
-__pthread_internal_list :: struct {
-	__prev: ^__pthread_internal_list,
-	__next: ^__pthread_internal_list,
-}
-__pthread_list_t :: __pthread_internal_list
-__pthread_internal_slist :: struct {
-	__next: ^__pthread_internal_slist,
-}
-__pthread_slist_t :: __pthread_internal_slist
-__pthread_mutex_s :: struct {
-	__lock:    i32,
-	__count:   u32,
-	__owner:   i32,
-	__nusers:  u32,
-	__kind:    i32,
-	__spins:   i16,
-	__elision: i16,
-	__list:    __pthread_list_t,
-}
-__pthread_rwlock_arch_t :: struct {
-	__readers:       u32,
-	__writers:       u32,
-	__wrphase_futex: u32,
-	__writers_futex: u32,
-	__pad3:          u32,
-	__pad4:          u32,
-	__cur_writer:    i32,
-	__shared:        i32,
-	__rwelision:     i8,
-	__pad1:          [7]u8,
-	__pad2:          u64,
-	__flags:         u32,
-}
-__pthread_cond_s :: struct {
-	__wseq:         __atomic_wide_counter,
-	__g1_start:     __atomic_wide_counter,
-	__g_refs:       [2]u32,
-	__g_size:       [2]u32,
-	__g1_orig_size: u32,
-	__wrefs:        u32,
-	__g_signals:    [2]u32,
-}
-__tss_t :: u32
-__thrd_t :: u64
-__once_flag :: struct {
-	__data: i32,
-}
-pthread_t :: u64
-pthread_mutexattr_t :: struct #raw_union {
-	__size:  [4]i8,
-	__align: i32,
-}
-pthread_condattr_t :: struct #raw_union {
-	__size:  [4]i8,
-	__align: i32,
-}
-pthread_key_t :: u32
-pthread_once_t :: i32
-pthread_attr_t :: struct #raw_union {
-	__size:  [56]i8,
-	__align: i64,
-}
-pthread_mutex_t :: struct #raw_union {
-	__data:  __pthread_mutex_s,
-	__size:  [40]i8,
-	__align: i64,
-}
-pthread_cond_t :: struct #raw_union {
-	__data:  __pthread_cond_s,
-	__size:  [48]i8,
-	__align: i64,
-}
-pthread_rwlock_t :: struct #raw_union {
-	__data:  __pthread_rwlock_arch_t,
-	__size:  [56]i8,
-	__align: i64,
-}
-pthread_rwlockattr_t :: struct #raw_union {
-	__size:  [8]i8,
-	__align: i64,
-}
-pthread_spinlock_t :: i32
-pthread_barrier_t :: struct #raw_union {
-	__size:  [32]i8,
-	__align: i64,
-}
-pthread_barrierattr_t :: struct #raw_union {
-	__size:  [4]i8,
-	__align: i32,
-}
-stat :: struct {
-	st_dev:           __dev_t,
-	st_ino:           __ino_t,
-	st_nlink:         __nlink_t,
-	st_mode:          __mode_t,
-	st_uid:           __uid_t,
-	st_gid:           __gid_t,
-	__pad0:           i32,
-	st_rdev:          __dev_t,
-	st_size:          __off_t,
-	st_blksize:       __blksize_t,
-	st_blocks:        __blkcnt_t,
-	st_atim:          timespec,
-	st_mtim:          timespec,
-	st_ctim:          timespec,
-	__glibc_reserved: [3]__syscall_slong_t,
-}
-flock :: struct {
-	l_type:   i16,
-	l_whence: i16,
-	l_start:  __off_t,
-	l_len:    __off_t,
-	l_pid:    __pid_t,
-}
-dirent :: struct {
-	d_ino:    __ino_t,
-	d_off:    __off_t,
-	d_reclen: u16,
-	d_type:   u8,
-	d_name:   [256]i8,
-}
-__dirstream :: ^^^rawptr
-DIR :: __dirstream
-__selector_func_ptr_anon_2 :: #type proc "c" (param0: ^dirent) -> i32
-__cmp_func_ptr_anon_3 :: #type proc "c" (param0: ^^dirent, param1: ^^dirent) -> i32
-iovec :: struct {
-	iov_base: rawptr,
-	iov_len:  u64,
-}
-socklen_t :: __socklen_t
-__socket_type :: enum u32 {
-	SOCK_STREAM    = 1,
-	SOCK_DGRAM     = 2,
-	SOCK_RAW       = 3,
-	SOCK_RDM       = 4,
-	SOCK_SEQPACKET = 5,
-	SOCK_DCCP      = 6,
-	SOCK_PACKET    = 10,
-	SOCK_CLOEXEC   = 524288,
-	SOCK_NONBLOCK  = 2048,
-}
-sa_family_t :: u16
-msghdr :: struct {
-	msg_name:       rawptr,
-	msg_namelen:    socklen_t,
-	msg_iov:        ^iovec,
-	msg_iovlen:     u64,
-	msg_control:    rawptr,
-	msg_controllen: u64,
-	msg_flags:      i32,
-}
-cmsghdr :: struct {
-	cmsg_len:    u64,
-	cmsg_level:  i32,
-	cmsg_type:   i32,
-	__cmsg_data: [^]u8,
-}
-__kernel_fd_set :: struct {
-	fds_bits: [16]u64,
-}
-__kernel_sighandler_t :: #type proc "c" (param0: i32)
-__kernel_key_t :: i32
-__kernel_mqd_t :: i32
-__kernel_old_uid_t :: u16
-__kernel_old_gid_t :: u16
-__kernel_old_dev_t :: u64
-__kernel_long_t :: i64
-__kernel_ulong_t :: u64
-__kernel_ino_t :: __kernel_ulong_t
-__kernel_mode_t :: u32
-__kernel_pid_t :: i32
-__kernel_ipc_pid_t :: i32
-__kernel_uid_t :: u32
-__kernel_gid_t :: u32
-__kernel_suseconds_t :: __kernel_long_t
-__kernel_daddr_t :: i32
-__kernel_uid32_t :: u32
-__kernel_gid32_t :: u32
-__kernel_size_t :: __kernel_ulong_t
-__kernel_ssize_t :: __kernel_long_t
-__kernel_ptrdiff_t :: __kernel_long_t
-__kernel_fsid_t :: struct {
-	val: [2]i32,
-}
-__kernel_off_t :: __kernel_long_t
-__kernel_loff_t :: i64
-__kernel_old_time_t :: __kernel_long_t
-__kernel_time_t :: __kernel_long_t
-__kernel_time64_t :: i64
-__kernel_clock_t :: __kernel_long_t
-__kernel_timer_t :: i32
-__kernel_clockid_t :: i32
-__kernel_caddr_t :: cstring
-__kernel_uid16_t :: u16
-__kernel_gid16_t :: u16
-linger :: struct {
-	l_onoff:  i32,
-	l_linger: i32,
-}
-osockaddr :: struct {
-	sa_family: u16,
-	sa_data:   [14]u8,
-}
-in_addr_t :: u32
-in_addr :: struct {
-	s_addr: in_addr_t,
-}
-ip_opts :: struct {
-	ip_dst:    in_addr,
-	ip_opts_m: [40]i8,
-}
-in_pktinfo :: struct {
-	ipi_ifindex:  i32,
-	ipi_spec_dst: in_addr,
-	ipi_addr:     in_addr,
-}
-in_port_t :: u16
-__in6_u_union_anon_4 :: struct #raw_union {
-	__u6_addr8:  [16]u8,
-	__u6_addr16: [8]u16,
-	__u6_addr32: [4]u32,
-}
-in6_addr :: struct {
-	__in6_u: __in6_u_union_anon_4,
-}
-ip_mreq :: struct {
-	imr_multiaddr: in_addr,
-	imr_interface: in_addr,
-}
-ip_mreqn :: struct {
-	imr_multiaddr: in_addr,
-	imr_address:   in_addr,
-	imr_ifindex:   i32,
-}
-ip_mreq_source :: struct {
-	imr_multiaddr:  in_addr,
-	imr_interface:  in_addr,
-	imr_sourceaddr: in_addr,
-}
-ipv6_mreq :: struct {
-	ipv6mr_multiaddr: in6_addr,
-	ipv6mr_interface: u32,
-}
-ip_msfilter :: struct {
-	imsf_multiaddr: in_addr,
-	imsf_interface: in_addr,
-	imsf_fmode:     u32,
-	imsf_numsrc:    u32,
-	imsf_slist:     [1]in_addr,
-}
-tcp_seq :: u32
+import "core:c/libc"
+import "core:sys/linux"
+import "core:sys/posix"
 
-tcphdr :: ^^^rawptr
-tcp_ca_state :: enum u32 {
-	TCP_CA_Open     = 0,
-	TCP_CA_Disorder = 1,
-	TCP_CA_CWR      = 2,
-	TCP_CA_Recovery = 3,
-	TCP_CA_Loss     = 4,
-}
-tcp_info :: ^^^rawptr
-tcp_repair_opt :: struct {
-	opt_code: u32,
-	opt_val:  u32,
-}
-tcp_cookie_transactions :: struct {
-	tcpct_flags:          u16,
-	__tcpct_pad1:         u8,
-	tcpct_cookie_desired: u8,
-	tcpct_s_data_desired: u16,
-	tcpct_used:           u16,
-	tcpct_value:          [536]u8,
-}
-tcp_repair_window :: struct {
-	snd_wl1:    u32,
-	snd_wnd:    u32,
-	max_window: u32,
-	rcv_wnd:    u32,
-	rcv_wup:    u32,
-}
-tcp_zerocopy_receive :: struct {
-	address:        u64,
-	length:         u32,
-	recv_skip_hint: u32,
-}
-rpcent :: struct {
-	r_name:    cstring,
-	r_aliases: [^]cstring,
-	r_number:  i32,
-}
-netent :: struct {
-	n_name:     cstring,
-	n_aliases:  [^]cstring,
-	n_addrtype: i32,
-	n_net:      u32,
-}
-hostent :: struct {
-	h_name:      cstring,
-	h_aliases:   [^]cstring,
-	h_addrtype:  i32,
-	h_length:    i32,
-	h_addr_list: ^cstring,
-}
-servent :: struct {
-	s_name:    cstring,
-	s_aliases: [^]cstring,
-	s_port:    i32,
-	s_proto:   cstring,
-}
-protoent :: struct {
-	p_name:    cstring,
-	p_aliases: [^]cstring,
-	p_proto:   i32,
-}
-addrinfo :: struct {
-	ai_flags:     i32,
-	ai_family:    i32,
-	ai_socktype:  i32,
-	ai_protocol:  i32,
-	ai_addrlen:   socklen_t,
-	ai_addr:      rawptr,
-	ai_canonname: cstring,
-	ai_next:      ^addrinfo,
-}
-cc_t :: u8
-speed_t :: u32
-tcflag_t :: u32
-termios :: struct {
-	c_iflag:  tcflag_t,
-	c_oflag:  tcflag_t,
-	c_cflag:  tcflag_t,
-	c_lflag:  tcflag_t,
-	c_line:   cc_t,
-	c_cc:     [32]cc_t,
-	c_ispeed: speed_t,
-	c_ospeed: speed_t,
-}
-passwd :: struct {
-	pw_name:   cstring,
-	pw_passwd: cstring,
-	pw_uid:    __uid_t,
-	pw_gid:    __gid_t,
-	pw_gecos:  cstring,
-	pw_dir:    cstring,
-	pw_shell:  cstring,
-}
-sem_t :: struct #raw_union {
-	__size:  [32]i8,
-	__align: i64,
-}
-sig_atomic_t :: __sig_atomic_t
-sigval :: struct #raw_union {
-	sival_int: i32,
-	sival_ptr: rawptr,
-}
-__sigval_t :: sigval
-_kill_struct_anon_5 :: struct {
-	si_pid: __pid_t,
-	si_uid: __uid_t,
-}
-_timer_struct_anon_6 :: struct {
-	si_tid:     i32,
-	si_overrun: i32,
-	si_sigval:  __sigval_t,
-}
-_rt_struct_anon_7 :: struct {
-	si_pid:    __pid_t,
-	si_uid:    __uid_t,
-	si_sigval: __sigval_t,
-}
-_sigchld_struct_anon_8 :: struct {
-	si_pid:    __pid_t,
-	si_uid:    __uid_t,
-	si_status: i32,
-	si_utime:  __clock_t,
-	si_stime:  __clock_t,
-}
-_addr_bnd_struct_anon_9 :: struct {
-	_lower: rawptr,
-	_upper: rawptr,
-}
-_bounds_union_anon_10 :: struct #raw_union {
-	_addr_bnd: _addr_bnd_struct_anon_9,
-	_pkey:     __uint32_t,
-}
-_sigfault_struct_anon_11 :: struct {
-	si_addr:     rawptr,
-	si_addr_lsb: i16,
-	_bounds:     _bounds_union_anon_10,
-}
-_sigpoll_struct_anon_12 :: struct {
-	si_band: i64,
-	si_fd:   i32,
-}
-_sigsys_struct_anon_13 :: struct {
-	_call_addr: rawptr,
-	_syscall:   i32,
-	_arch:      u32,
-}
-_sifields_union_anon_14 :: struct #raw_union {
-	_pad:      [28]i32,
-	_kill:     _kill_struct_anon_5,
-	_timer:    _timer_struct_anon_6,
-	_rt:       _rt_struct_anon_7,
-	_sigchld:  _sigchld_struct_anon_8,
-	_sigfault: _sigfault_struct_anon_11,
-	_sigpoll:  _sigpoll_struct_anon_12,
-	_sigsys:   _sigsys_struct_anon_13,
-}
-siginfo_t :: struct {
-	si_signo:  i32,
-	si_errno:  i32,
-	si_code:   i32,
-	__pad0:    i32,
-	_sifields: _sifields_union_anon_14,
-}
-sigval_t :: __sigval_t
-_function_func_ptr_anon_15 :: #type proc "c" (param0: __sigval_t)
-_sigev_thread_struct_anon_16 :: struct {
-	_function:  _function_func_ptr_anon_15,
-	_attribute: ^pthread_attr_t,
-}
-_sigev_un_union_anon_17 :: struct #raw_union {
-	_pad:          [12]i32,
-	_tid:          __pid_t,
-	_sigev_thread: _sigev_thread_struct_anon_16,
-}
-sigevent :: ^^^rawptr
-sigevent_t :: sigevent
-__sighandler_t :: #type proc "c" (param0: i32)
-sig_t :: __sighandler_t
-sa_sigaction_func_ptr_anon_18 :: #type proc "c" (param0: i32, param1: ^siginfo_t, param2: rawptr)
-__sigaction_handler_union_anon_19 :: struct #raw_union {
-	sa_handler:   __sighandler_t,
-	sa_sigaction: sa_sigaction_func_ptr_anon_18,
-}
-sa_restorer_func_ptr_anon_20 :: #type proc "c" ()
-sigaction :: struct {
-	__sigaction_handler: __sigaction_handler_union_anon_19,
-	sa_mask:             __sigset_t,
-	sa_flags:            i32,
-	sa_restorer:         sa_restorer_func_ptr_anon_20,
-}
-_fpx_sw_bytes :: struct {
-	magic1:            __uint32_t,
-	extended_size:     __uint32_t,
-	xstate_bv:         __uint64_t,
-	xstate_size:       __uint32_t,
-	__glibc_reserved1: [7]__uint32_t,
-}
-_fpreg :: struct {
-	significand: [4]u16,
-	exponent:    u16,
-}
-_fpxreg :: struct {
-	significand:       [4]u16,
-	exponent:          u16,
-	__glibc_reserved1: [3]u16,
-}
-_xmmreg :: struct {
-	element: [4]__uint32_t,
-}
-_fpstate :: struct {
-	cwd:               __uint16_t,
-	swd:               __uint16_t,
-	ftw:               __uint16_t,
-	fop:               __uint16_t,
-	rip:               __uint64_t,
-	rdp:               __uint64_t,
-	mxcsr:             __uint32_t,
-	mxcr_mask:         __uint32_t,
-	_st:               [8]_fpxreg,
-	_xmm:              [16]_xmmreg,
-	__glibc_reserved1: [24]__uint32_t,
-}
-sigcontext :: struct {
-	r8:          __uint64_t,
-	r9:          __uint64_t,
-	r10:         __uint64_t,
-	r11:         __uint64_t,
-	r12:         __uint64_t,
-	r13:         __uint64_t,
-	r14:         __uint64_t,
-	r15:         __uint64_t,
-	rdi:         __uint64_t,
-	rsi:         __uint64_t,
-	rbp:         __uint64_t,
-	rbx:         __uint64_t,
-	rdx:         __uint64_t,
-	rax:         __uint64_t,
-	rcx:         __uint64_t,
-	rsp:         __uint64_t,
-	rip:         __uint64_t,
-	eflags:      __uint64_t,
-	cs:          u16,
-	gs:          u16,
-	fs:          u16,
-	__pad0:      u16,
-	err:         __uint64_t,
-	trapno:      __uint64_t,
-	oldmask:     __uint64_t,
-	cr2:         __uint64_t,
-	__reserved1: [8]__uint64_t,
-}
-_xsave_hdr :: struct {
-	xstate_bv:         __uint64_t,
-	__glibc_reserved1: [2]__uint64_t,
-	__glibc_reserved2: [5]__uint64_t,
-}
-_ymmh_state :: struct {
-	ymmh_space: [64]__uint32_t,
-}
-_xstate :: struct {
-	fpstate:    _fpstate,
-	xstate_hdr: _xsave_hdr,
-	ymmh:       _ymmh_state,
-}
-stack_t :: struct {
-	ss_sp:    rawptr,
-	ss_flags: i32,
-	ss_size:  u64,
-}
-greg_t :: i64
-gregset_t :: [23]greg_t
-_libc_fpxreg :: struct {
-	significand:       [4]u16,
-	exponent:          u16,
-	__glibc_reserved1: [3]u16,
-}
-_libc_xmmreg :: struct {
-	element: [4]__uint32_t,
-}
-_libc_fpstate :: struct {
-	cwd:               __uint16_t,
-	swd:               __uint16_t,
-	ftw:               __uint16_t,
-	fop:               __uint16_t,
-	rip:               __uint64_t,
-	rdp:               __uint64_t,
-	mxcsr:             __uint32_t,
-	mxcr_mask:         __uint32_t,
-	_st:               [8]_libc_fpxreg,
-	_xmm:              [16]_libc_xmmreg,
-	__glibc_reserved1: [24]__uint32_t,
-}
-fpregset_t :: ^_libc_fpstate
-mcontext_t :: struct {
-	gregs:       gregset_t,
-	fpregs:      fpregset_t,
-	__reserved1: [8]u64,
-}
-ucontext_t :: struct {
-	uc_flags:     u64,
-	uc_link:      ^ucontext_t,
-	uc_stack:     stack_t,
-	uc_mcontext:  mcontext_t,
-	uc_sigmask:   sigset_t,
-	__fpregs_mem: _libc_fpstate,
-	__ssp:        [4]u64,
-}
-sigstack :: struct {
-	ss_sp:      rawptr,
-	ss_onstack: i32,
-}
-sched_param :: struct {
-	sched_priority: i32,
-}
-__cpu_mask :: u64
-cpu_set_t :: struct {
-	__bits: [16]__cpu_mask,
-}
-tm :: struct {
-	tm_sec:    i32,
-	tm_min:    i32,
-	tm_hour:   i32,
-	tm_mday:   i32,
-	tm_mon:    i32,
-	tm_year:   i32,
-	tm_wday:   i32,
-	tm_yday:   i32,
-	tm_isdst:  i32,
-	tm_gmtoff: i64,
-	tm_zone:   cstring,
-}
-itimerspec :: struct {
-	it_interval: timespec,
-	it_value:    timespec,
-}
-__locale_data :: ^^^rawptr
-__locale_struct :: struct {
-	__locales:       ^[13][^]__locale_data,
-	__ctype_b:       ^u16,
-	__ctype_tolower: ^i32,
-	__ctype_toupper: ^i32,
-	__names:         [13]cstring,
-}
-__locale_t :: ^__locale_struct
-locale_t :: __locale_t
-__jmp_buf :: [8]i64
-__jmp_buf_tag :: struct {
-	__jmpbuf:         __jmp_buf,
-	__mask_was_saved: i32,
-	__saved_mask:     __sigset_t,
-}
-__routine_func_ptr_anon_21 :: #type proc "c" (param0: rawptr)
-_pthread_cleanup_buffer :: struct {
-	__routine:    __routine_func_ptr_anon_21,
-	__arg:        rawptr,
-	__canceltype: i32,
-	__prev:       ^_pthread_cleanup_buffer,
-}
-__start_routine_func_ptr_anon_22 :: #type proc "c" (param0: rawptr) -> rawptr
-__init_routine_func_ptr_anon_23 :: #type proc "c" ()
-__cancel_jmp_buf_tag :: struct {
-	__cancel_jmp_buf: __jmp_buf,
-	__mask_was_saved: i32,
-}
-__pthread_unwind_buf_t :: struct {
-	__cancel_jmp_buf: [1]__cancel_jmp_buf_tag,
-	__pad:            [4]rawptr,
-}
-__cancel_routine_func_ptr_anon_24 :: #type proc "c" (param0: rawptr)
-__pthread_cleanup_frame :: struct {
-	__cancel_routine: __cancel_routine_func_ptr_anon_24,
-	__cancel_arg:     rawptr,
-	__do_it:          i32,
-	__cancel_type:    i32,
-}
-__destr_function_func_ptr_anon_25 :: #type proc "c" (param0: rawptr)
-__prepare_func_ptr_anon_26 :: #type proc "c" ()
-__parent_func_ptr_anon_27 :: #type proc "c" ()
-__child_func_ptr_anon_28 :: #type proc "c" ()
-work_func_ptr_anon_29 :: #type proc "c" (w: ^uv__work)
-done_func_ptr_anon_30 :: #type proc "c" (w: ^uv__work, status: i32)
-active_reqs_union_anon_53 :: struct #raw_union {
-	unused: rawptr,
-	count:  u32,
-}
-uv_mutex_t :: pthread_mutex_t
-uv_rwlock_t :: pthread_rwlock_t
-async_unused_func_ptr_anon_54 :: #type proc "c" ()
-timer_heap_struct_anon_55 :: struct {
-	min:   rawptr,
-	nelts: u32,
-}
-uv_loop_s :: struct {
-	data:                 rawptr,
-	active_handles:       u32,
-	handle_queue:         uv__queue,
-	active_reqs:          active_reqs_union_anon_53,
-	internal_fields:      rawptr,
-	stop_flag:            u32,
-	flags:                u64,
-	backend_fd:           i32,
-	pending_queue:        uv__queue,
-	watcher_queue:        uv__queue,
-	watchers:             ^[^]uv__io_t,
-	nwatchers:            u32,
-	nfds:                 u32,
-	wq:                   uv__queue,
-	wq_mutex:             uv_mutex_t,
-	wq_async:             uv_async_t,
-	cloexec_lock:         uv_rwlock_t,
-	closing_handles:      [^]uv_handle_t,
-	process_handles:      uv__queue,
-	prepare_handles:      uv__queue,
-	check_handles:        uv__queue,
-	idle_handles:         uv__queue,
-	async_handles:        uv__queue,
-	async_unused:         async_unused_func_ptr_anon_54,
-	async_io_watcher:     uv__io_t,
-	async_wfd:            i32,
-	timer_heap:           timer_heap_struct_anon_55,
-	timer_counter:        u64,
-	time:                 u64,
-	signal_pipefd:        [2]i32,
-	signal_io_watcher:    uv__io_t,
-	child_watcher:        uv_signal_t,
-	emfile_fd:            i32,
-	inotify_read_watcher: uv__io_t,
-	inotify_watchers:     rawptr,
-	inotify_fd:           i32,
-}
-uv__work :: struct {
-	work: work_func_ptr_anon_29,
-	done: done_func_ptr_anon_30,
-	loop: ^uv_loop_s,
-	wq:   uv__queue,
-}
-uv__io_s :: struct {
-	cb:            uv__io_cb,
-	pending_queue: uv__queue,
-	watcher_queue: uv__queue,
-	pevents:       u32,
-	events:        u32,
-	fd:            i32,
-}
-uv__io_cb :: #type proc "c" (loop: ^uv_loop_s, w: ^uv__io_s, events: u32)
-uv__io_t :: uv__io_s
-uv_buf_t :: struct {
-	base: cstring,
-	len:  u64,
-}
-uv_file :: i32
-uv_os_sock_t :: i32
-uv_os_fd_t :: i32
-uv_pid_t :: pid_t
-uv_once_t :: pthread_once_t
-uv_thread_t :: pthread_t
-uv_sem_t :: sem_t
-uv_cond_t :: pthread_cond_t
-uv_key_t :: pthread_key_t
-uv_barrier_t :: pthread_barrier_t
-uv_gid_t :: gid_t
-uv_uid_t :: uid_t
-uv__dirent_t :: dirent
-uv_lib_t :: struct {
-	handle: rawptr,
-	errmsg: cstring,
-}
-uv_errno_t :: enum i32 {
-	E2BIG           = -7,
-	EACCES          = -13,
-	EADDRINUSE      = -98,
-	EADDRNOTAVAIL   = -99,
-	EAFNOSUPPORT    = -97,
-	EAGAIN          = -11,
-	EAI_ADDRFAMILY  = -3000,
-	EAI_AGAIN       = -3001,
-	EAI_BADFLAGS    = -3002,
-	EAI_BADHINTS    = -3013,
-	EAI_CANCELED    = -3003,
-	EAI_FAIL        = -3004,
-	EAI_FAMILY      = -3005,
-	EAI_MEMORY      = -3006,
-	EAI_NODATA      = -3007,
-	EAI_NONAME      = -3008,
-	EAI_OVERFLOW    = -3009,
-	EAI_PROTOCOL    = -3014,
-	EAI_SERVICE     = -3010,
-	EAI_SOCKTYPE    = -3011,
-	EALREADY        = -114,
-	EBADF           = -9,
-	EBUSY           = -16,
-	ECANCELED       = -125,
-	ECHARSET        = -4080,
-	ECONNABORTED    = -103,
-	ECONNREFUSED    = -111,
-	ECONNRESET      = -104,
-	EDESTADDRREQ    = -89,
-	EEXIST          = -17,
-	EFAULT          = -14,
-	EFBIG           = -27,
-	EHOSTUNREACH    = -113,
-	EINTR           = -4,
-	EINVAL          = -22,
-	EIO             = -5,
-	EISCONN         = -106,
-	EISDIR          = -21,
-	ELOOP           = -40,
-	EMFILE          = -24,
-	EMSGSIZE        = -90,
-	ENAMETOOLONG    = -36,
-	ENETDOWN        = -100,
-	ENETUNREACH     = -101,
-	ENFILE          = -23,
-	ENOBUFS         = -105,
-	ENODEV          = -19,
-	ENOENT          = -2,
-	ENOMEM          = -12,
-	ENONET          = -64,
-	ENOPROTOOPT     = -92,
-	ENOSPC          = -28,
-	ENOSYS          = -38,
-	ENOTCONN        = -107,
-	ENOTDIR         = -20,
-	ENOTEMPTY       = -39,
-	ENOTSOCK        = -88,
-	ENOTSUP         = -95,
-	EOVERFLOW       = -75,
-	EPERM           = -1,
-	EPIPE           = -32,
-	EPROTO          = -71,
-	EPROTONOSUPPORT = -93,
-	EPROTOTYPE      = -91,
-	ERANGE          = -34,
-	EROFS           = -30,
-	ESHUTDOWN       = -108,
-	ESPIPE          = -29,
-	ESRCH           = -3,
-	ETIMEDOUT       = -110,
-	ETXTBSY         = -26,
-	EXDEV           = -18,
-	UNKNOWN         = -4094,
-	EOF             = -4095,
-	ENXIO           = -6,
-	EMLINK          = -31,
-	EHOSTDOWN       = -112,
-	EREMOTEIO       = -121,
-	ENOTTY          = -25,
-	EFTYPE          = -4028,
-	EILSEQ          = -84,
-	ESOCKTNOSUPPORT = -94,
-	ENODATA         = -61,
-	EUNATCH         = -49,
-	ERRNO_MAX       = -4096,
-}
-uv_handle_type :: enum u32 {
-	UNKNOWN_HANDLE  = 0,
-	ASYNC           = 1,
-	CHECK           = 2,
-	FS_EVENT        = 3,
-	FS_POLL         = 4,
-	HANDLE          = 5,
-	IDLE            = 6,
-	NAMED_PIPE      = 7,
-	POLL            = 8,
-	PREPARE         = 9,
-	PROCESS         = 10,
-	STREAM          = 11,
-	TCP             = 12,
-	TIMER           = 13,
-	TTY             = 14,
-	UDP             = 15,
-	SIGNAL          = 16,
-	FILE            = 17,
-	HANDLE_TYPE_MAX = 18,
-}
-uv_req_type :: enum u32 {
-	UNKNOWN_REQ  = 0,
-	REQ          = 1,
-	CONNECT      = 2,
-	WRITE        = 3,
-	SHUTDOWN     = 4,
-	UDP_SEND     = 5,
-	FS           = 6,
-	WORK         = 7,
-	GETADDRINFO  = 8,
-	GETNAMEINFO  = 9,
-	RANDOM       = 10,
-	REQ_TYPE_MAX = 11,
-}
-uv_loop_t :: uv_loop_s
-u_union_anon_31 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_handle_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_31,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-}
-uv_handle_t :: uv_handle_s
-uv_dirent_type_t :: enum u32 {
-	DIRENT_UNKNOWN = 0,
-	DIRENT_FILE    = 1,
-	DIRENT_DIR     = 2,
-	DIRENT_LINK    = 3,
-	DIRENT_FIFO    = 4,
-	DIRENT_SOCKET  = 5,
-	DIRENT_CHAR    = 6,
-	DIRENT_BLOCK   = 7,
-}
-uv_dirent_s :: struct {
-	name: cstring,
-	type: uv_dirent_type_t,
-}
-uv_dirent_t :: uv_dirent_s
-uv_dir_s :: struct {
-	dirents:  [^]uv_dirent_t,
-	nentries: u64,
-	reserved: [4]rawptr,
-	dir:      ^DIR,
-}
-uv_dir_t :: uv_dir_s
-uv_close_cb :: #type proc "c" (handle: ^uv_handle_t)
-u_union_anon_32 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_alloc_cb :: #type proc "c" (handle: ^uv_handle_t, suggested_size: u64, buf: ^uv_buf_t)
-uv_stream_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_32,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      u64,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-}
-uv_stream_t :: uv_stream_s
-u_union_anon_33 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_read_cb :: #type proc "c" (stream: ^uv_stream_t, nread: ssize_t, buf: ^uv_buf_t)
-uv_connect_t :: uv_connect_s
-uv_shutdown_t :: uv_shutdown_s
-uv_connection_cb :: #type proc "c" (server: ^uv_stream_t, status: i32)
-uv_tcp_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_33,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      u64,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-}
-uv_tcp_t :: uv_tcp_s
-u_union_anon_34 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_udp_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_34,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	send_queue_size:       u64,
-	send_queue_count:      u64,
-	alloc_cb:              uv_alloc_cb,
-	recv_cb:               uv_udp_recv_cb,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-}
-uv_udp_t :: uv_udp_s
-u_union_anon_36 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_pipe_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_36,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      u64,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-	ipc:                   i32,
-	pipe_fname:            cstring,
-}
-uv_pipe_t :: uv_pipe_s
-u_union_anon_35 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_tty_s :: struct {
-	data:                  rawptr,
-	loop:                  ^uv_loop_t,
-	type:                  uv_handle_type,
-	close_cb:              uv_close_cb,
-	handle_queue:          uv__queue,
-	u:                     u_union_anon_35,
-	next_closing:          ^uv_handle_t,
-	flags:                 u32,
-	write_queue_size:      u64,
-	alloc_cb:              uv_alloc_cb,
-	read_cb:               uv_read_cb,
-	connect_req:           ^uv_connect_t,
-	shutdown_req:          ^uv_shutdown_t,
-	io_watcher:            uv__io_t,
-	write_queue:           uv__queue,
-	write_completed_queue: uv__queue,
-	connection_cb:         uv_connection_cb,
-	delayed_error:         i32,
-	accepted_fd:           i32,
-	queued_fds:            rawptr,
-	orig_termios:          termios,
-	mode:                  i32,
-}
-uv_tty_t :: uv_tty_s
-u_union_anon_37 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_poll_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_37,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	poll_cb:      uv_poll_cb,
-	io_watcher:   uv__io_t,
-}
-uv_poll_t :: uv_poll_s
-u_union_anon_42 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-node_union_anon_43 :: struct #raw_union {
-	heap:  [3]rawptr,
-	queue: uv__queue,
-}
-uv_timer_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_42,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	timer_cb:     uv_timer_cb,
-	node:         node_union_anon_43,
-	timeout:      u64,
-	repeat:       u64,
-	start_id:     u64,
-}
-uv_timer_t :: uv_timer_s
-u_union_anon_38 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_prepare_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_38,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	prepare_cb:   uv_prepare_cb,
-	queue:        uv__queue,
-}
-uv_prepare_t :: uv_prepare_s
-u_union_anon_39 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_check_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_39,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	check_cb:     uv_check_cb,
-	queue:        uv__queue,
-}
-uv_check_t :: uv_check_s
-u_union_anon_40 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_idle_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_40,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	idle_cb:      uv_idle_cb,
-	queue:        uv__queue,
-}
-uv_idle_t :: uv_idle_s
-u_union_anon_41 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_async_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_41,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	async_cb:     uv_async_cb,
-	queue:        uv__queue,
-	pending:      i32,
-}
-uv_async_t :: uv_async_s
-u_union_anon_45 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_process_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_45,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	exit_cb:      uv_exit_cb,
-	pid:          i32,
-	queue:        uv__queue,
-	status:       i32,
-}
-uv_process_t :: uv_process_s
-u_union_anon_48 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_fs_event_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_48,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	path:         cstring,
-	cb:           uv_fs_event_cb,
-	watchers:     uv__queue,
-	wd:           i32,
-}
-uv_fs_event_t :: uv_fs_event_s
-u_union_anon_49 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_fs_poll_s :: struct {
-	data:         rawptr,
-	loop:         ^uv_loop_t,
-	type:         uv_handle_type,
-	close_cb:     uv_close_cb,
-	handle_queue: uv__queue,
-	u:            u_union_anon_49,
-	next_closing: ^uv_handle_t,
-	flags:        u32,
-	poll_ctx:     rawptr,
-}
-uv_fs_poll_t :: uv_fs_poll_s
-u_union_anon_50 :: struct #raw_union {
-	fd:       i32,
-	reserved: [4]rawptr,
-}
-uv_signal_s :: struct {
-	data:               rawptr,
-	loop:               ^uv_loop_t,
-	type:               uv_handle_type,
-	close_cb:           uv_close_cb,
-	handle_queue:       uv__queue,
-	u:                  u_union_anon_50,
-	next_closing:       ^uv_handle_t,
-	flags:              u32,
-	signal_cb:          uv_signal_cb,
-	signum:             i32,
-	tree_entry:         tree_entry_struct_anon_51,
-	caught_signals:     u32,
-	dispatched_signals: u32,
-}
-uv_signal_t :: uv_signal_s
-uv_req_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-}
-uv_req_t :: uv_req_s
-uv_getaddrinfo_s :: struct {
-	data:       rawptr,
-	type:       uv_req_type,
-	reserved:   [6]rawptr,
-	loop:       ^uv_loop_t,
-	work_req:   uv__work,
-	cb:         uv_getaddrinfo_cb,
-	hints:      [^]addrinfo,
-	hostname:   cstring,
-	service:    cstring,
-	addrinfo_m: ^addrinfo,
-	retcode:    i32,
-}
-uv_getaddrinfo_t :: uv_getaddrinfo_s
-uv_getnameinfo_t :: uv_getnameinfo_s
-uv_shutdown_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	handle:   ^uv_stream_t,
-	cb:       uv_shutdown_cb,
-}
-uv_write_s :: struct {
-	data:        rawptr,
-	type:        uv_req_type,
-	reserved:    [6]rawptr,
-	cb:          uv_write_cb,
-	send_handle: ^uv_stream_t,
-	handle:      ^uv_stream_t,
-	queue:       uv__queue,
-	write_index: u32,
-	bufs:        [^]uv_buf_t,
-	nbufs:       u32,
-	error:       i32,
-	bufsml:      [4]uv_buf_t,
-}
-uv_write_t :: uv_write_s
-uv_connect_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	cb:       uv_connect_cb,
-	handle:   ^uv_stream_t,
-	queue:    uv__queue,
-}
-sockaddr_storage :: ^^^rawptr
+pthread_rwlock_t :: [56]i8
+queue :: struct {
+    next: ^queue,
+    prev: ^queue,
+}
+errno_t :: enum i32 {E2BIG = -4093, EACCES = -4092, EADDRINUSE = -4091, EADDRNOTAVAIL = -4090, EAFNOSUPPORT = -4089, EAGAIN = -4088, EAI_ADDRFAMILY = -3000, EAI_AGAIN = -3001, EAI_BADFLAGS = -3002, EAI_BADHINTS = -3013, EAI_CANCELED = -3003, EAI_FAIL = -3004, EAI_FAMILY = -3005, EAI_MEMORY = -3006, EAI_NODATA = -3007, EAI_NONAME = -3008, EAI_OVERFLOW = -3009, EAI_PROTOCOL = -3014, EAI_SERVICE = -3010, EAI_SOCKTYPE = -3011, EALREADY = -4084, EBADF = -4083, EBUSY = -4082, ECANCELED = -4081, ECHARSET = -4080, ECONNABORTED = -4079, ECONNREFUSED = -4078, ECONNRESET = -4077, EDESTADDRREQ = -4076, EEXIST = -4075, EFAULT = -4074, EFBIG = -4036, EHOSTUNREACH = -4073, EINTR = -4072, EINVAL = -4071, EIO = -4070, EISCONN = -4069, EISDIR = -4068, ELOOP = -4067, EMFILE = -4066, EMSGSIZE = -4065, ENAMETOOLONG = -4064, ENETDOWN = -4063, ENETUNREACH = -4062, ENFILE = -4061, ENOBUFS = -4060, ENODEV = -4059, ENOENT = -4058, ENOMEM = -4057, ENONET = -4056, ENOPROTOOPT = -4035, ENOSPC = -4055, ENOSYS = -4054, ENOTCONN = -4053, ENOTDIR = -4052, ENOTEMPTY = -4051, ENOTSOCK = -4050, ENOTSUP = -4049, EOVERFLOW = -4026, EPERM = -4048, EPIPE = -4047, EPROTO = -4046, EPROTONOSUPPORT = -4045, EPROTOTYPE = -4044, ERANGE = -4034, EROFS = -4043, ESHUTDOWN = -4042, ESPIPE = -4041, ESRCH = -4040, ETIMEDOUT = -4039, ETXTBSY = -4038, EXDEV = -4037, UNKNOWN = -4094, EOF = -4095, ENXIO = -4033, EMLINK = -4032, EHOSTDOWN = -4031, EREMOTEIO = -4030, ENOTTY = -4029, EFTYPE = -4028, EILSEQ = -4027, ESOCKTNOSUPPORT = -4025, ENODATA = -4024, EUNATCH = -4023, ERRNO_MAX = -4096, }
+handle_type :: enum u32 {UNKNOWN_HANDLE = 0, ASYNC = 1, CHECK = 2, FS_EVENT = 3, FS_POLL = 4, HANDLE = 5, IDLE = 6, NAMED_PIPE = 7, POLL = 8, PREPARE = 9, PROCESS = 10, STREAM = 11, TCP = 12, TIMER = 13, TTY = 14, UDP = 15, SIGNAL = 16, FILE = 17, HANDLE_TYPE_MAX = 18, }
+req_type :: enum u32 {UNKNOWN_REQ = 0, REQ = 1, CONNECT = 2, WRITE = 3, SHUTDOWN = 4, UDP_SEND = 5, FS = 6, WORK = 7, GETADDRINFO = 8, GETNAMEINFO = 9, RANDOM = 10, REQ_TYPE_MAX = 11, }
+loop_t :: loop_s
+u_union_anon_0 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+handle_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_0,
+    next_closing: ^handle_t,
+    flags: u32,
+}
+handle_t :: handle_s
+dirent_type_t :: enum u32 {DIRENT_UNKNOWN = 0, DIRENT_FILE = 1, DIRENT_DIR = 2, DIRENT_LINK = 3, DIRENT_FIFO = 4, DIRENT_SOCKET = 5, DIRENT_CHAR = 6, DIRENT_BLOCK = 7, }
+dirent_s :: struct {
+    name: cstring,
+    type: dirent_type_t,
+}
+dirent_t :: dirent_s
+dir_s :: struct {
+    dirents: [^]dirent_t,
+    nentries: u64,
+    reserved: [4]rawptr,
+    dir: ^posix.DIR,
+}
+dir_t :: dir_s
+close_cb :: #type proc "c" (handle: ^handle_t)
+u_union_anon_1 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+buf_t :: struct {
+    base: cstring,
+    len: u64,
+}
+alloc_cb :: #type proc "c" (handle: ^handle_t, suggested_size: u64, buf: ^buf_t)
+io_t :: io_s
+stream_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_1,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+}
+stream_t :: stream_s
+u_union_anon_2 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+read_cb :: #type proc "c" (stream: ^stream_t, nread: i64, buf: ^buf_t)
+connect_t :: connect_s
+shutdown_t :: shutdown_s
+connection_cb :: #type proc "c" (server: ^stream_t, status: i32)
+tcp_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_2,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+}
+tcp_t :: tcp_s
+u_union_anon_3 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+udp_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_3,
+    next_closing: ^handle_t,
+    flags: u32,
+    send_queue_size: u64,
+    send_queue_count: u64,
+    alloc_cb_m: alloc_cb,
+    recv_cb: udp_recv_cb,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+}
+udp_t :: udp_s
+u_union_anon_5 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+pipe_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_5,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+    ipc: i32,
+    pipe_fname: cstring,
+}
+pipe_t :: pipe_s
+u_union_anon_4 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+tty_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_4,
+    next_closing: ^handle_t,
+    flags: u32,
+    write_queue_size: u64,
+    alloc_cb_m: alloc_cb,
+    read_cb_m: read_cb,
+    connect_req: ^connect_t,
+    shutdown_req: ^shutdown_t,
+    io_watcher: io_t,
+    write_queue: queue,
+    write_completed_queue: queue,
+    connection_cb_m: connection_cb,
+    delayed_error: i32,
+    accepted_fd: i32,
+    queued_fds: rawptr,
+    orig_termios: posix.termios,
+    mode: i32,
+}
+tty_t :: tty_s
+u_union_anon_6 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+poll_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_6,
+    next_closing: ^handle_t,
+    flags: u32,
+    poll_cb_m: poll_cb,
+    io_watcher: io_t,
+}
+poll_t :: poll_s
+u_union_anon_11 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+node_union_anon_12 :: struct #raw_union {heap: [3]rawptr, queue_m: queue, }
+timer_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_11,
+    next_closing: ^handle_t,
+    flags: u32,
+    timer_cb_m: timer_cb,
+    node: node_union_anon_12,
+    timeout: u64,
+    repeat: u64,
+    start_id: u64,
+}
+timer_t :: timer_s
+u_union_anon_7 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+prepare_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_7,
+    next_closing: ^handle_t,
+    flags: u32,
+    prepare_cb_m: prepare_cb,
+    queue_m: queue,
+}
+prepare_t :: prepare_s
+u_union_anon_8 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+check_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_8,
+    next_closing: ^handle_t,
+    flags: u32,
+    check_cb_m: check_cb,
+    queue_m: queue,
+}
+check_t :: check_s
+u_union_anon_9 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+idle_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_9,
+    next_closing: ^handle_t,
+    flags: u32,
+    idle_cb_m: idle_cb,
+    queue_m: queue,
+}
+idle_t :: idle_s
+u_union_anon_10 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+async_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_10,
+    next_closing: ^handle_t,
+    flags: u32,
+    async_cb_m: async_cb,
+    queue_m: queue,
+    pending: i32,
+}
+async_t :: async_s
+u_union_anon_14 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+process_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_14,
+    next_closing: ^handle_t,
+    flags: u32,
+    exit_cb_m: exit_cb,
+    pid: i32,
+    queue_m: queue,
+    status: i32,
+}
+process_t :: process_s
+u_union_anon_17 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+fs_event_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_17,
+    next_closing: ^handle_t,
+    flags: u32,
+    path: cstring,
+    cb: fs_event_cb,
+    watchers: queue,
+    wd: i32,
+}
+fs_event_t :: fs_event_s
+u_union_anon_18 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+fs_poll_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_18,
+    next_closing: ^handle_t,
+    flags: u32,
+    poll_ctx: rawptr,
+}
+fs_poll_t :: fs_poll_s
+u_union_anon_19 :: struct #raw_union {fd: i32, reserved: [4]rawptr, }
+signal_s :: struct {
+    data: rawptr,
+    loop: ^loop_t,
+    type: handle_type,
+    close_cb_m: close_cb,
+    handle_queue: queue,
+    u: u_union_anon_19,
+    next_closing: ^handle_t,
+    flags: u32,
+    signal_cb_m: signal_cb,
+    signum: i32,
+    tree_entry: tree_entry_struct_anon_20,
+    caught_signals: u32,
+    dispatched_signals: u32,
+}
+signal_t :: signal_s
+req_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+}
+req_t :: req_s
+active_reqs_union_anon_22 :: struct #raw_union {unused: rawptr, count: u32, }
+mutex_t :: posix.pthread_mutex_t
+rwlock_t :: pthread_rwlock_t
+async_unused_func_ptr_anon_23 :: #type proc "c" ()
+timer_heap_struct_anon_24 :: struct {
+    min: rawptr,
+    nelts: u32,
+}
+loop_s :: struct {
+    data: rawptr,
+    active_handles: u32,
+    handle_queue: queue,
+    active_reqs: active_reqs_union_anon_22,
+    internal_fields: rawptr,
+    stop_flag: u32,
+    flags: u64,
+    backend_fd: i32,
+    pending_queue: queue,
+    watcher_queue: queue,
+    watchers: ^[^]io_t,
+    nwatchers: u32,
+    nfds: u32,
+    wq: queue,
+    wq_mutex: mutex_t,
+    wq_async: async_t,
+    cloexec_lock: rwlock_t,
+    closing_handles: [^]handle_t,
+    process_handles: queue,
+    prepare_handles: queue,
+    check_handles: queue,
+    idle_handles: queue,
+    async_handles: queue,
+    async_unused: async_unused_func_ptr_anon_23,
+    async_io_watcher: io_t,
+    async_wfd: i32,
+    timer_heap: timer_heap_struct_anon_24,
+    timer_counter: u64,
+    time: u64,
+    signal_pipefd: [2]i32,
+    signal_io_watcher: io_t,
+    child_watcher: signal_t,
+    emfile_fd: i32,
+    inotify_read_watcher: io_t,
+    inotify_watchers: rawptr,
+    inotify_fd: i32,
+}
+work :: struct {
+    work_m: work_func_ptr_anon_25,
+    done: done_func_ptr_anon_26,
+    loop: ^loop_s,
+    wq: queue,
+}
+getaddrinfo_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_req: work,
+    cb: getaddrinfo_cb,
+    hints: [^]posix.addrinfo,
+    hostname: cstring,
+    service: cstring,
+    addrinfo: ^posix.addrinfo,
+    retcode: i32,
+}
+getaddrinfo_t :: getaddrinfo_s
+getnameinfo_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_req: work,
+    getnameinfo_cb_m: getnameinfo_cb,
+    storage: posix.sockaddr_storage,
+    flags: i32,
+    host: [1025]i8,
+    service: [32]i8,
+    retcode: i32,
+}
+getnameinfo_t :: getnameinfo_s
+shutdown_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    handle: ^stream_t,
+    cb: shutdown_cb,
+}
+write_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    cb: write_cb,
+    send_handle: ^stream_t,
+    handle: ^stream_t,
+    queue_m: queue,
+    write_index: u32,
+    bufs: [^]buf_t,
+    nbufs: u32,
+    error: i32,
+    bufsml: [4]buf_t,
+}
+write_t :: write_s
+connect_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    cb: connect_cb,
+    handle: ^stream_t,
+    queue_m: queue,
+}
+udp_send_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    handle: ^udp_t,
+    cb: udp_send_cb,
+    queue_m: queue,
+    addr: posix.sockaddr_storage,
+    nbufs: u32,
+    bufs: [^]buf_t,
+    status: i64,
+    send_cb: udp_send_cb,
+    bufsml: [4]buf_t,
+}
+udp_send_t :: udp_send_s
+fs_type :: enum i32 {FS_UNKNOWN = -1, FS_CUSTOM = 0, FS_OPEN = 1, FS_CLOSE = 2, FS_READ = 3, FS_WRITE = 4, FS_SENDFILE = 5, FS_STAT = 6, FS_LSTAT = 7, FS_FSTAT = 8, FS_FTRUNCATE = 9, FS_UTIME = 10, FS_FUTIME = 11, FS_ACCESS = 12, FS_CHMOD = 13, FS_FCHMOD = 14, FS_FSYNC = 15, FS_FDATASYNC = 16, FS_UNLINK = 17, FS_RMDIR = 18, FS_MKDIR = 19, FS_MKDTEMP = 20, FS_RENAME = 21, FS_SCANDIR = 22, FS_LINK = 23, FS_SYMLINK = 24, FS_READLINK = 25, FS_CHOWN = 26, FS_FCHOWN = 27, FS_REALPATH = 28, FS_COPYFILE = 29, FS_LCHOWN = 30, FS_OPENDIR = 31, FS_READDIR = 32, FS_CLOSEDIR = 33, FS_STATFS = 34, FS_MKSTEMP = 35, FS_LUTIME = 36, }
+timespec_t :: struct {
+    tv_sec: i64,
+    tv_nsec: i64,
+}
+stat_t :: struct {
+    st_dev: u64,
+    st_mode: u64,
+    st_nlink: u64,
+    st_uid: u64,
+    st_gid: u64,
+    st_rdev: u64,
+    st_ino: u64,
+    st_size: u64,
+    st_blksize: u64,
+    st_blocks: u64,
+    st_flags: u64,
+    st_gen: u64,
+    st_atim: timespec_t,
+    st_mtim: timespec_t,
+    st_ctim: timespec_t,
+    st_birthtim: timespec_t,
+}
+file :: i32
+uid_t :: linux.Uid
+gid_t :: linux.Gid
+fs_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    fs_type_m: fs_type,
+    loop: ^loop_t,
+    cb: fs_cb,
+    result: i64,
+    ptr: rawptr,
+    path: cstring,
+    statbuf: stat_t,
+    new_path: cstring,
+    file_m: file,
+    flags: i32,
+    mode: posix.mode_t,
+    nbufs: u32,
+    bufs: [^]buf_t,
+    off: posix.off_t,
+    uid: uid_t,
+    gid: gid_t,
+    atime: f64,
+    mtime: f64,
+    work_req: work,
+    bufsml: [4]buf_t,
+}
+fs_t :: fs_s
+work_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    work_cb_m: work_cb,
+    after_work_cb_m: after_work_cb,
+    work_req: work,
+}
+work_t :: work_s
+random_s :: struct {
+    data: rawptr,
+    type: req_type,
+    reserved: [6]rawptr,
+    loop: ^loop_t,
+    status: i32,
+    buf: rawptr,
+    buflen: u64,
+    cb: random_cb,
+    work_req: work,
+}
+random_t :: random_s
+env_item_s :: struct {
+    name: cstring,
+    value: cstring,
+}
+env_item_t :: env_item_s
+cpu_times_s :: struct {
+    user: u64,
+    nice: u64,
+    sys: u64,
+    idle: u64,
+    irq: u64,
+}
+cpu_info_s :: struct {
+    model: cstring,
+    speed: i32,
+    cpu_times: cpu_times_s,
+}
+cpu_info_t :: cpu_info_s
+address_union_anon_15 :: struct #raw_union {address4: posix.sockaddr_in, address6: posix.sockaddr_in6, }
+netmask_union_anon_16 :: struct #raw_union {netmask4: posix.sockaddr_in, netmask6: posix.sockaddr_in6, }
+interface_address_s :: struct {
+    name: cstring,
+    phys_addr: [6]i8,
+    is_internal: i32,
+    address: address_union_anon_15,
+    netmask: netmask_union_anon_16,
+}
+interface_address_t :: interface_address_s
+passwd_s :: struct {
+    username: cstring,
+    uid: u64,
+    gid: u64,
+    shell: cstring,
+    homedir: cstring,
+}
+passwd_t :: passwd_s
+group_s :: struct {
+    groupname: cstring,
+    gid: u64,
+    members: [^]cstring,
+}
+group_t :: group_s
+utsname_s :: struct {
+    sysname: [256]i8,
+    release: [256]i8,
+    version: [256]i8,
+    machine: [256]i8,
+}
+utsname_t :: utsname_s
+statfs_s :: struct {
+    f_type: u64,
+    f_bsize: u64,
+    f_blocks: u64,
+    f_bfree: u64,
+    f_bavail: u64,
+    f_files: u64,
+    f_ffree: u64,
+    f_spare: [4]u64,
+}
+statfs_t :: statfs_s
+metrics_s :: struct {
+    loop_count: u64,
+    events: u64,
+    events_waiting: u64,
+    reserved: ^[13]^u64,
+}
+metrics_t :: metrics_s
+loop_option :: enum u32 {LOOP_BLOCK_SIGNAL = 0, METRICS_IDLE_TIME = 1, LOOP_USE_IO_URING_SQPOLL = 2, }
+run_mode :: enum u32 {RUN_DEFAULT = 0, RUN_ONCE = 1, RUN_NOWAIT = 2, }
+malloc_func :: #type proc "c" (size: u64) -> rawptr
+realloc_func :: #type proc "c" (ptr: rawptr, size: u64) -> rawptr
+calloc_func :: #type proc "c" (count: u64, size: u64) -> rawptr
+free_func :: #type proc "c" (ptr: rawptr)
+write_cb :: #type proc "c" (req: ^write_t, status: i32)
+connect_cb :: #type proc "c" (req: ^connect_t, status: i32)
+shutdown_cb :: #type proc "c" (req: ^shutdown_t, status: i32)
+poll_cb :: #type proc "c" (handle: ^poll_t, status: i32, events: i32)
+timer_cb :: #type proc "c" (handle: ^timer_t)
+async_cb :: #type proc "c" (handle: ^async_t)
+prepare_cb :: #type proc "c" (handle: ^prepare_t)
+check_cb :: #type proc "c" (handle: ^check_t)
+idle_cb :: #type proc "c" (handle: ^idle_t)
+exit_cb :: #type proc "c" (param0: ^process_t, exit_status: i64, term_signal: i32)
+walk_cb :: #type proc "c" (handle: ^handle_t, arg: rawptr)
+fs_cb :: #type proc "c" (req: ^fs_t)
+work_cb :: #type proc "c" (req: ^work_t)
+after_work_cb :: #type proc "c" (req: ^work_t, status: i32)
+getaddrinfo_cb :: #type proc "c" (req: ^getaddrinfo_t, status: i32, res: [^]posix.addrinfo)
+getnameinfo_cb :: #type proc "c" (req: ^getnameinfo_t, status: i32, hostname: cstring, service: cstring)
+random_cb :: #type proc "c" (req: ^random_t, status: i32, buf: rawptr, buflen: u64)
+clock_id :: enum u32 {CLOCK_MONOTONIC = 0, CLOCK_REALTIME = 1, }
+timespec64_t :: struct {
+    tv_sec: i64,
+    tv_nsec: i32,
+}
+timeval_t :: struct {
+    tv_sec: i64,
+    tv_usec: i64,
+}
+timeval64_t :: struct {
+    tv_sec: i64,
+    tv_usec: i32,
+}
+fs_event_cb :: #type proc "c" (handle: ^fs_event_t, filename: cstring, events: i32, status: i32)
+fs_poll_cb :: #type proc "c" (handle: ^fs_poll_t, status: i32, prev: ^stat_t, curr: ^stat_t)
+signal_cb :: #type proc "c" (handle: ^signal_t, signum: i32)
+membership :: enum u32 {LEAVE_GROUP = 0, JOIN_GROUP = 1, }
+tcp_flags :: enum u32 {TCP_IPV6ONLY = 1, TCP_REUSEPORT = 2, }
+udp_flags :: enum u32 {UDP_IPV6ONLY = 1, UDP_PARTIAL = 2, UDP_REUSEADDR = 4, UDP_MMSG_CHUNK = 8, UDP_MMSG_FREE = 16, UDP_LINUX_RECVERR = 32, UDP_REUSEPORT = 64, UDP_RECVMMSG = 256, }
+udp_send_cb :: #type proc "c" (req: ^udp_send_t, status: i32)
+udp_recv_cb :: #type proc "c" (handle: ^udp_t, nread: i64, buf: ^buf_t, addr: ^posix.sockaddr, flags: u32)
+tty_mode_t :: enum u32 {TTY_MODE_NORMAL = 0, TTY_MODE_RAW = 1, TTY_MODE_IO = 2, }
+tty_vtermstate_t :: enum u32 {TTY_SUPPORTED = 0, TTY_UNSUPPORTED = 1, }
+poll_event :: enum u32 {READABLE = 1, WRITABLE = 2, DISCONNECT = 4, PRIORITIZED = 8, }
+stdio_flags :: enum u32 {IGNORE = 0, CREATE_PIPE = 1, INHERIT_FD = 2, INHERIT_STREAM = 4, READABLE_PIPE = 16, WRITABLE_PIPE = 32, NONBLOCK_PIPE = 64, OVERLAPPED_PIPE = 64, }
+data_union_anon_13 :: struct #raw_union {stream: ^stream_t, fd: i32, }
+stdio_container_s :: struct {
+    flags: stdio_flags,
+    data: data_union_anon_13,
+}
+stdio_container_t :: stdio_container_s
+process_options_s :: struct {
+    exit_cb_m: exit_cb,
+    file_m: cstring,
+    args: [^]cstring,
+    env: ^cstring,
+    cwd: cstring,
+    flags: u32,
+    stdio_count: i32,
+    stdio: ^stdio_container_t,
+    uid: uid_t,
+    gid: gid_t,
+}
+process_options_t :: process_options_s
+process_flags :: enum u32 {PROCESS_SETUID = 1, PROCESS_SETGID = 2, PROCESS_WINDOWS_VERBATIM_ARGUMENTS = 4, PROCESS_DETACHED = 8, PROCESS_WINDOWS_HIDE = 16, PROCESS_WINDOWS_HIDE_CONSOLE = 32, PROCESS_WINDOWS_HIDE_GUI = 64, PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = 128, }
+rusage_t :: struct {
+    ru_utime: timeval_t,
+    ru_stime: timeval_t,
+    ru_maxrss: u64,
+    ru_ixrss: u64,
+    ru_idrss: u64,
+    ru_isrss: u64,
+    ru_minflt: u64,
+    ru_majflt: u64,
+    ru_nswap: u64,
+    ru_inblock: u64,
+    ru_oublock: u64,
+    ru_msgsnd: u64,
+    ru_msgrcv: u64,
+    ru_nsignals: u64,
+    ru_nvcsw: u64,
+    ru_nivcsw: u64,
+}
+fs_event :: enum u32 {RENAME = 1, CHANGE = 2, }
+tree_entry_struct_anon_20 :: struct {
+    rbe_left: ^signal_s,
+    rbe_right: ^signal_s,
+    rbe_parent: ^signal_s,
+    rbe_color: i32,
+}
+fs_event_flags :: enum u32 {FS_EVENT_WATCH_ENTRY = 1, FS_EVENT_STAT = 2, FS_EVENT_RECURSIVE = 4, }
+callback_func_ptr_anon_21 :: #type proc "c" ()
+thread_cb :: #type proc "c" (arg: rawptr)
+thread_create_flags :: enum u32 {THREAD_NO_FLAGS = 0, THREAD_HAS_STACK_SIZE = 1, }
+thread_options_s :: struct {
+    flags: u32,
+    stack_size: u64,
+}
+thread_options_t :: thread_options_s
+any_handle :: struct #raw_union {async: async_t, check: check_t, fs_event_m: fs_event_t, fs_poll: fs_poll_t, handle: handle_t, idle: idle_t, pipe: pipe_t, poll: poll_t, prepare: prepare_t, process: process_t, stream: stream_t, tcp: tcp_t, timer: timer_t, tty: tty_t, udp: udp_t, signal: signal_t, }
+any_req :: struct #raw_union {req: req_t, connect: connect_t, write: write_t, shutdown: shutdown_t, udp_send: udp_send_t, fs: fs_t, work_m: work_t, getaddrinfo: getaddrinfo_t, getnameinfo: getnameinfo_t, random: random_t, }
+work_func_ptr_anon_25 :: #type proc "c" (w: ^work)
+done_func_ptr_anon_26 :: #type proc "c" (w: ^work, status: i32)
+os_fd_t :: i32
+os_sock_t :: i32
+pid_t :: linux.Pid
+thread_t :: posix.pthread_t
+lib_t :: struct {
+    handle: rawptr,
+    errmsg: cstring,
+}
+sem_t :: [32]u8
+cond_t :: posix.pthread_cond_t
+_uv_barrier :: struct {
+    mutex: mutex_t,
+    cond: cond_t,
+    threshold: u32,
+    in_m: u32,
+    out: u32,
+}
+barrier_t :: struct {
+    b: ^_uv_barrier,
+}
+key_t :: posix.pthread_key_t
+io_s :: struct {
+    cb: io_cb,
+    pending_queue: queue,
+    watcher_queue: queue,
+    pevents: u32,
+    events: u32,
+    fd: i32,
+}
+io_cb :: #type proc "c" (loop: ^loop_s, w: ^io_s, events: u32)
 
-uv_getnameinfo_s :: struct {
-	data:           rawptr,
-	type:           uv_req_type,
-	reserved:       [6]rawptr,
-	loop:           ^uv_loop_t,
-	work_req:       uv__work,
-	getnameinfo_cb: uv_getnameinfo_cb,
-	storage:        sockaddr_storage,
-	flags:          i32,
-	host:           [1025]i8,
-	service:        [32]i8,
-	retcode:        i32,
+when #config(UV_STATIC, false) {
+    foreign import uv_runic "system:libuv.a"
+} else {
+    foreign import uv_runic "system:uv"
 }
-
-
-uv_udp_send_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	handle:   ^uv_udp_t,
-	cb:       uv_udp_send_cb,
-	queue:    uv__queue,
-	addr:     sockaddr_storage,
-	nbufs:    u32,
-	bufs:     [^]uv_buf_t,
-	status:   i32,
-	send_cb:  uv_udp_send_cb,
-	bufsml:   [4]uv_buf_t,
-}
-
-uv_udp_send_t :: uv_udp_send_s
-uv_fs_type :: enum i32 {
-	FS_UNKNOWN   = -1,
-	FS_CUSTOM    = 0,
-	FS_OPEN      = 1,
-	FS_CLOSE     = 2,
-	FS_READ      = 3,
-	FS_WRITE     = 4,
-	FS_SENDFILE  = 5,
-	FS_STAT      = 6,
-	FS_LSTAT     = 7,
-	FS_FSTAT     = 8,
-	FS_FTRUNCATE = 9,
-	FS_UTIME     = 10,
-	FS_FUTIME    = 11,
-	FS_ACCESS    = 12,
-	FS_CHMOD     = 13,
-	FS_FCHMOD    = 14,
-	FS_FSYNC     = 15,
-	FS_FDATASYNC = 16,
-	FS_UNLINK    = 17,
-	FS_RMDIR     = 18,
-	FS_MKDIR     = 19,
-	FS_MKDTEMP   = 20,
-	FS_RENAME    = 21,
-	FS_SCANDIR   = 22,
-	FS_LINK      = 23,
-	FS_SYMLINK   = 24,
-	FS_READLINK  = 25,
-	FS_CHOWN     = 26,
-	FS_FCHOWN    = 27,
-	FS_REALPATH  = 28,
-	FS_COPYFILE  = 29,
-	FS_LCHOWN    = 30,
-	FS_OPENDIR   = 31,
-	FS_READDIR   = 32,
-	FS_CLOSEDIR  = 33,
-	FS_STATFS    = 34,
-	FS_MKSTEMP   = 35,
-	FS_LUTIME    = 36,
-}
-uv_timespec_t :: struct {
-	tv_sec:  i64,
-	tv_nsec: i64,
-}
-uv_stat_t :: struct {
-	st_dev:      u64,
-	st_mode:     u64,
-	st_nlink:    u64,
-	st_uid:      u64,
-	st_gid:      u64,
-	st_rdev:     u64,
-	st_ino:      u64,
-	st_size:     u64,
-	st_blksize:  u64,
-	st_blocks:   u64,
-	st_flags:    u64,
-	st_gen:      u64,
-	st_atim:     uv_timespec_t,
-	st_mtim:     uv_timespec_t,
-	st_ctim:     uv_timespec_t,
-	st_birthtim: uv_timespec_t,
-}
-uv_fs_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	fs_type:  uv_fs_type,
-	loop:     ^uv_loop_t,
-	cb:       uv_fs_cb,
-	result:   ssize_t,
-	ptr:      rawptr,
-	path:     cstring,
-	statbuf:  uv_stat_t,
-	new_path: cstring,
-	file:     uv_file,
-	flags:    i32,
-	mode:     mode_t,
-	nbufs:    u32,
-	bufs:     [^]uv_buf_t,
-	off:      off_t,
-	uid:      uv_uid_t,
-	gid:      uv_gid_t,
-	atime:    f64,
-	mtime:    f64,
-	work_req: uv__work,
-	bufsml:   [4]uv_buf_t,
-}
-uv_fs_t :: uv_fs_s
-uv_work_s :: struct {
-	data:          rawptr,
-	type:          uv_req_type,
-	reserved:      [6]rawptr,
-	loop:          ^uv_loop_t,
-	work_cb:       uv_work_cb,
-	after_work_cb: uv_after_work_cb,
-	work_req:      uv__work,
-}
-uv_work_t :: uv_work_s
-uv_random_s :: struct {
-	data:     rawptr,
-	type:     uv_req_type,
-	reserved: [6]rawptr,
-	loop:     ^uv_loop_t,
-	status:   i32,
-	buf:      rawptr,
-	buflen:   u64,
-	cb:       uv_random_cb,
-	work_req: uv__work,
-}
-uv_random_t :: uv_random_s
-uv_env_item_s :: struct {
-	name:  cstring,
-	value: cstring,
-}
-uv_env_item_t :: uv_env_item_s
-uv_cpu_times_s :: struct {
-	user: u64,
-	nice: u64,
-	sys:  u64,
-	idle: u64,
-	irq:  u64,
-}
-uv_cpu_info_s :: struct {
-	model:     cstring,
-	speed:     i32,
-	cpu_times: uv_cpu_times_s,
-}
-uv_cpu_info_t :: uv_cpu_info_s
-sockaddr_in :: ^^^rawptr
-sockaddr_in6 :: ^^^rawptr
-address_union_anon_15 :: struct #raw_union {
-	address4: sockaddr_in,
-	address6: sockaddr_in6,
-}
-netmask_union_anon_16 :: struct #raw_union {
-	netmask4: sockaddr_in,
-	netmask6: sockaddr_in6,
-}
-uv_interface_address_s :: struct {
-	name:        cstring,
-	phys_addr:   [6]i8,
-	is_internal: i32,
-	address:     address_union_anon_15,
-	netmask:     netmask_union_anon_16,
-}
-uv_interface_address_t :: uv_interface_address_s
-uv_passwd_s :: struct {
-	username: cstring,
-	uid:      u64,
-	gid:      u64,
-	shell:    cstring,
-	homedir:  cstring,
-}
-uv_passwd_t :: uv_passwd_s
-uv_group_s :: struct {
-	groupname: cstring,
-	gid:       u64,
-	members:   [^]cstring,
-}
-uv_group_t :: uv_group_s
-uv_utsname_s :: struct {
-	sysname: [256]i8,
-	release: [256]i8,
-	version: [256]i8,
-	machine: [256]i8,
-}
-uv_utsname_t :: uv_utsname_s
-uv_statfs_s :: struct {
-	f_type:   u64,
-	f_bsize:  u64,
-	f_blocks: u64,
-	f_bfree:  u64,
-	f_bavail: u64,
-	f_files:  u64,
-	f_ffree:  u64,
-	f_spare:  [4]u64,
-}
-uv_statfs_t :: uv_statfs_s
-uv_metrics_s :: struct {
-	loop_count:     u64,
-	events:         u64,
-	events_waiting: u64,
-	reserved:       ^[13]^u64,
-}
-uv_metrics_t :: uv_metrics_s
-uv_loop_option :: enum u32 {
-	LOOP_BLOCK_SIGNAL        = 0,
-	METRICS_IDLE_TIME        = 1,
-	LOOP_USE_IO_URING_SQPOLL = 2,
-}
-uv_run_mode :: enum u32 {
-	RUN_DEFAULT = 0,
-	RUN_ONCE    = 1,
-	RUN_NOWAIT  = 2,
-}
-uv_malloc_func :: #type proc "c" (size: u64) -> rawptr
-uv_realloc_func :: #type proc "c" (ptr: rawptr, size: u64) -> rawptr
-uv_calloc_func :: #type proc "c" (count: u64, size: u64) -> rawptr
-uv_free_func :: #type proc "c" (ptr: rawptr)
-uv_write_cb :: #type proc "c" (req: ^uv_write_t, status: i32)
-uv_connect_cb :: #type proc "c" (req: ^uv_connect_t, status: i32)
-uv_shutdown_cb :: #type proc "c" (req: ^uv_shutdown_t, status: i32)
-uv_poll_cb :: #type proc "c" (handle: ^uv_poll_t, status: i32, events: i32)
-uv_timer_cb :: #type proc "c" (handle: ^uv_timer_t)
-uv_async_cb :: #type proc "c" (handle: ^uv_async_t)
-uv_prepare_cb :: #type proc "c" (handle: ^uv_prepare_t)
-uv_check_cb :: #type proc "c" (handle: ^uv_check_t)
-uv_idle_cb :: #type proc "c" (handle: ^uv_idle_t)
-uv_exit_cb :: #type proc "c" (param0: ^uv_process_t, exit_status: i64, term_signal: i32)
-uv_walk_cb :: #type proc "c" (handle: ^uv_handle_t, arg: rawptr)
-uv_fs_cb :: #type proc "c" (req: ^uv_fs_t)
-uv_work_cb :: #type proc "c" (req: ^uv_work_t)
-uv_after_work_cb :: #type proc "c" (req: ^uv_work_t, status: i32)
-uv_getaddrinfo_cb :: #type proc "c" (req: ^uv_getaddrinfo_t, status: i32, res: [^]addrinfo)
-uv_getnameinfo_cb :: #type proc "c" (
-	req: ^uv_getnameinfo_t,
-	status: i32,
-	hostname: cstring,
-	service: cstring,
-)
-uv_random_cb :: #type proc "c" (req: ^uv_random_t, status: i32, buf: rawptr, buflen: u64)
-uv_clock_id :: enum u32 {
-	CLOCK_MONOTONIC = 0,
-	CLOCK_REALTIME  = 1,
-}
-uv_timespec64_t :: struct {
-	tv_sec:  i64,
-	tv_nsec: i32,
-}
-uv_timeval_t :: struct {
-	tv_sec:  i64,
-	tv_usec: i64,
-}
-uv_timeval64_t :: struct {
-	tv_sec:  i64,
-	tv_usec: i32,
-}
-uv_fs_event_cb :: #type proc "c" (
-	handle: ^uv_fs_event_t,
-	filename: cstring,
-	events: i32,
-	status: i32,
-)
-uv_fs_poll_cb :: #type proc "c" (
-	handle: ^uv_fs_poll_t,
-	status: i32,
-	prev: ^uv_stat_t,
-	curr: ^uv_stat_t,
-)
-uv_signal_cb :: #type proc "c" (handle: ^uv_signal_t, signum: i32)
-uv_membership :: enum u32 {
-	LEAVE_GROUP = 0,
-	JOIN_GROUP  = 1,
-}
-uv_tcp_flags :: enum u32 {
-	TCP_IPV6ONLY  = 1,
-	TCP_REUSEPORT = 2,
-}
-uv_udp_flags :: enum u32 {
-	UDP_IPV6ONLY      = 1,
-	UDP_PARTIAL       = 2,
-	UDP_REUSEADDR     = 4,
-	UDP_MMSG_CHUNK    = 8,
-	UDP_MMSG_FREE     = 16,
-	UDP_LINUX_RECVERR = 32,
-	UDP_REUSEPORT     = 64,
-	UDP_RECVMMSG      = 256,
-}
-uv_udp_send_cb :: #type proc "c" (req: ^uv_udp_send_t, status: i32)
-uv_udp_recv_cb :: #type proc "c" (
-	handle: ^uv_udp_t,
-	nread: ssize_t,
-	buf: ^uv_buf_t,
-	addr: rawptr,
-	flags: u32,
-)
-uv_tty_mode_t :: enum u32 {
-	TTY_MODE_NORMAL = 0,
-	TTY_MODE_RAW    = 1,
-	TTY_MODE_IO     = 2,
-}
-uv_tty_vtermstate_t :: enum u32 {
-	TTY_SUPPORTED   = 0,
-	TTY_UNSUPPORTED = 1,
-}
-uv_poll_event :: enum u32 {
-	READABLE    = 1,
-	WRITABLE    = 2,
-	DISCONNECT  = 4,
-	PRIORITIZED = 8,
-}
-uv_stdio_flags :: enum u32 {
-	IGNORE          = 0,
-	CREATE_PIPE     = 1,
-	INHERIT_FD      = 2,
-	INHERIT_STREAM  = 4,
-	READABLE_PIPE   = 16,
-	WRITABLE_PIPE   = 32,
-	NONBLOCK_PIPE   = 64,
-	OVERLAPPED_PIPE = 64,
-}
-data_union_anon_44 :: struct #raw_union {
-	stream: ^uv_stream_t,
-	fd:     i32,
-}
-uv_stdio_container_s :: struct {
-	flags: uv_stdio_flags,
-	data:  data_union_anon_44,
-}
-uv_stdio_container_t :: uv_stdio_container_s
-uv_process_options_s :: struct {
-	exit_cb:     uv_exit_cb,
-	file:        cstring,
-	args:        [^]cstring,
-	env:         ^cstring,
-	cwd:         cstring,
-	flags:       u32,
-	stdio_count: i32,
-	stdio:       ^uv_stdio_container_t,
-	uid:         uv_uid_t,
-	gid:         uv_gid_t,
-}
-uv_process_options_t :: uv_process_options_s
-uv_process_flags :: enum u32 {
-	PROCESS_SETUID                       = 1,
-	PROCESS_SETGID                       = 2,
-	PROCESS_WINDOWS_VERBATIM_ARGUMENTS   = 4,
-	PROCESS_DETACHED                     = 8,
-	PROCESS_WINDOWS_HIDE                 = 16,
-	PROCESS_WINDOWS_HIDE_CONSOLE         = 32,
-	PROCESS_WINDOWS_HIDE_GUI             = 64,
-	PROCESS_WINDOWS_FILE_PATH_EXACT_NAME = 128,
-}
-uv_rusage_t :: struct {
-	ru_utime:    uv_timeval_t,
-	ru_stime:    uv_timeval_t,
-	ru_maxrss:   u64,
-	ru_ixrss:    u64,
-	ru_idrss:    u64,
-	ru_isrss:    u64,
-	ru_minflt:   u64,
-	ru_majflt:   u64,
-	ru_nswap:    u64,
-	ru_inblock:  u64,
-	ru_oublock:  u64,
-	ru_msgsnd:   u64,
-	ru_msgrcv:   u64,
-	ru_nsignals: u64,
-	ru_nvcsw:    u64,
-	ru_nivcsw:   u64,
-}
-uv_fs_event :: enum u32 {
-	RENAME = 1,
-	CHANGE = 2,
-}
-tree_entry_struct_anon_51 :: struct {
-	rbe_left:   ^uv_signal_s,
-	rbe_right:  ^uv_signal_s,
-	rbe_parent: ^uv_signal_s,
-	rbe_color:  i32,
-}
-uv_fs_event_flags :: enum u32 {
-	FS_EVENT_WATCH_ENTRY = 1,
-	FS_EVENT_STAT        = 2,
-	FS_EVENT_RECURSIVE   = 4,
-}
-callback_func_ptr_anon_52 :: #type proc "c" ()
-uv_thread_cb :: #type proc "c" (arg: rawptr)
-uv_thread_create_flags :: enum u32 {
-	THREAD_NO_FLAGS       = 0,
-	THREAD_HAS_STACK_SIZE = 1,
-}
-uv_thread_options_s :: struct {
-	flags:      u32,
-	stack_size: u64,
-}
-uv_thread_options_t :: uv_thread_options_s
-uv_any_handle :: struct #raw_union {
-	async:    uv_async_t,
-	check:    uv_check_t,
-	fs_event: uv_fs_event_t,
-	fs_poll:  uv_fs_poll_t,
-	handle:   uv_handle_t,
-	idle:     uv_idle_t,
-	pipe:     uv_pipe_t,
-	poll:     uv_poll_t,
-	prepare:  uv_prepare_t,
-	process:  uv_process_t,
-	stream:   uv_stream_t,
-	tcp:      uv_tcp_t,
-	timer:    uv_timer_t,
-	tty:      uv_tty_t,
-	udp:      uv_udp_t,
-	signal:   uv_signal_t,
-}
-uv_any_req :: struct #raw_union {
-	req:         uv_req_t,
-	connect:     uv_connect_t,
-	write:       uv_write_t,
-	shutdown:    uv_shutdown_t,
-	udp_send:    uv_udp_send_t,
-	fs:          uv_fs_t,
-	work:        uv_work_t,
-	getaddrinfo: uv_getaddrinfo_t,
-	getnameinfo: uv_getnameinfo_t,
-	random:      uv_random_t,
-}
-
-foreign import uv_runic "system:libuv.a"
 
 @(default_calling_convention = "c")
 foreign uv_runic {
+    @(link_name = "uv_version")
+    version :: proc() -> u32 ---
 
-	@(link_name = "uv_version")
-	version :: proc() -> u32 ---
+    @(link_name = "uv_version_string")
+    version_string :: proc() -> cstring ---
 
-	@(link_name = "uv_version_string")
-	version_string :: proc() -> cstring ---
+    @(link_name = "uv_library_shutdown")
+    library_shutdown :: proc() ---
 
-	@(link_name = "uv_library_shutdown")
-	library_shutdown :: proc() ---
+    @(link_name = "uv_replace_allocator")
+    replace_allocator :: proc(malloc_func_p: malloc_func, realloc_func_p: realloc_func, calloc_func_p: calloc_func, free_func_p: free_func) -> i32 ---
 
-	@(link_name = "uv_replace_allocator")
-	replace_allocator :: proc(malloc_func: uv_malloc_func, realloc_func: uv_realloc_func, calloc_func: uv_calloc_func, free_func: uv_free_func) -> i32 ---
+    @(link_name = "uv_default_loop")
+    default_loop :: proc() -> ^loop_t ---
 
-	@(link_name = "uv_default_loop")
-	default_loop :: proc() -> ^uv_loop_t ---
+    @(link_name = "uv_loop_init")
+    loop_init :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_init")
-	loop_init :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_close")
+    loop_close :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_close")
-	loop_close :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_new")
+    loop_new :: proc() -> ^loop_t ---
 
-	@(link_name = "uv_loop_new")
-	loop_new :: proc() -> ^uv_loop_t ---
+    @(link_name = "uv_loop_delete")
+    loop_delete :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_loop_delete")
-	loop_delete :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_loop_size")
+    loop_size :: proc() -> u64 ---
 
-	@(link_name = "uv_loop_size")
-	loop_size :: proc() -> u64 ---
+    @(link_name = "uv_loop_alive")
+    loop_alive :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_alive")
-	loop_alive :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_loop_configure")
+    loop_configure :: proc(loop: ^loop_t, option: loop_option, #c_vararg var_args: ..any) -> i32 ---
 
-	@(link_name = "uv_loop_configure")
-	loop_configure :: proc(loop: ^uv_loop_t, option: uv_loop_option) -> i32 ---
+    @(link_name = "uv_loop_fork")
+    loop_fork :: proc(loop: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_loop_fork")
-	loop_fork :: proc(loop: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_run")
+    run :: proc(param0: ^loop_t, mode: run_mode) -> i32 ---
 
-	@(link_name = "uv_run")
-	run :: proc(param0: ^uv_loop_t, mode: uv_run_mode) -> i32 ---
+    @(link_name = "uv_stop")
+    stop :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_stop")
-	stop :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_ref")
+    ref :: proc(param0: ^handle_t) ---
 
-	@(link_name = "uv_ref")
-	ref :: proc(param0: ^uv_handle_t) ---
+    @(link_name = "uv_unref")
+    unref :: proc(param0: ^handle_t) ---
 
-	@(link_name = "uv_unref")
-	unref :: proc(param0: ^uv_handle_t) ---
+    @(link_name = "uv_has_ref")
+    has_ref :: proc(param0: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_has_ref")
-	has_ref :: proc(param0: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_update_time")
+    update_time :: proc(param0: ^loop_t) ---
 
-	@(link_name = "uv_update_time")
-	update_time :: proc(param0: ^uv_loop_t) ---
+    @(link_name = "uv_now")
+    now :: proc(param0: ^loop_t) -> u64 ---
 
-	@(link_name = "uv_now")
-	now :: proc(param0: ^uv_loop_t) -> u64 ---
+    @(link_name = "uv_backend_fd")
+    backend_fd :: proc(param0: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_backend_fd")
-	backend_fd :: proc(param0: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_backend_timeout")
+    backend_timeout :: proc(param0: ^loop_t) -> i32 ---
 
-	@(link_name = "uv_backend_timeout")
-	backend_timeout :: proc(param0: ^uv_loop_t) -> i32 ---
+    @(link_name = "uv_translate_sys_error")
+    translate_sys_error :: proc(sys_errno: i32) -> i32 ---
 
-	@(link_name = "uv_translate_sys_error")
-	translate_sys_error :: proc(sys_errno: i32) -> i32 ---
+    @(link_name = "uv_strerror")
+    strerror :: proc(err: i32) -> cstring ---
 
-	@(link_name = "uv_strerror")
-	strerror :: proc(err: i32) -> cstring ---
+    @(link_name = "uv_strerror_r")
+    strerror_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
 
-	@(link_name = "uv_strerror_r")
-	strerror_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
+    @(link_name = "uv_err_name")
+    err_name :: proc(err: i32) -> cstring ---
 
-	@(link_name = "uv_err_name")
-	err_name :: proc(err: i32) -> cstring ---
+    @(link_name = "uv_err_name_r")
+    err_name_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
 
-	@(link_name = "uv_err_name_r")
-	err_name_r :: proc(err: i32, buf: cstring, buflen: u64) -> cstring ---
+    @(link_name = "uv_shutdown")
+    shutdown :: proc(req: ^shutdown_t, handle: ^stream_t, cb: shutdown_cb) -> i32 ---
 
-	@(link_name = "uv_shutdown")
-	shutdown :: proc(req: ^uv_shutdown_t, handle: ^uv_stream_t, cb: uv_shutdown_cb) -> i32 ---
+    @(link_name = "uv_handle_size")
+    handle_size :: proc(type: handle_type) -> u64 ---
 
-	@(link_name = "uv_handle_size")
-	handle_size :: proc(type: uv_handle_type) -> u64 ---
+    @(link_name = "uv_handle_get_type")
+    handle_get_type :: proc(handle: ^handle_t) -> handle_type ---
 
-	@(link_name = "uv_handle_get_type")
-	handle_get_type :: proc(handle: ^uv_handle_t) -> uv_handle_type ---
+    @(link_name = "uv_handle_type_name")
+    handle_type_name :: proc(type: handle_type) -> cstring ---
 
-	@(link_name = "uv_handle_type_name")
-	handle_type_name :: proc(type: uv_handle_type) -> cstring ---
+    @(link_name = "uv_handle_get_data")
+    handle_get_data :: proc(handle: ^handle_t) -> rawptr ---
 
-	@(link_name = "uv_handle_get_data")
-	handle_get_data :: proc(handle: ^uv_handle_t) -> rawptr ---
+    @(link_name = "uv_handle_get_loop")
+    handle_get_loop :: proc(handle: ^handle_t) -> ^loop_t ---
 
-	@(link_name = "uv_handle_get_loop")
-	handle_get_loop :: proc(handle: ^uv_handle_t) -> ^uv_loop_t ---
+    @(link_name = "uv_handle_set_data")
+    handle_set_data :: proc(handle: ^handle_t, data: rawptr) ---
 
-	@(link_name = "uv_handle_set_data")
-	handle_set_data :: proc(handle: ^uv_handle_t, data: rawptr) ---
+    @(link_name = "uv_req_size")
+    req_size :: proc(type: req_type) -> u64 ---
 
-	@(link_name = "uv_req_size")
-	req_size :: proc(type: uv_req_type) -> u64 ---
+    @(link_name = "uv_req_get_data")
+    req_get_data :: proc(req: ^req_t) -> rawptr ---
 
-	@(link_name = "uv_req_get_data")
-	req_get_data :: proc(req: ^uv_req_t) -> rawptr ---
+    @(link_name = "uv_req_set_data")
+    req_set_data :: proc(req: ^req_t, data: rawptr) ---
 
-	@(link_name = "uv_req_set_data")
-	req_set_data :: proc(req: ^uv_req_t, data: rawptr) ---
+    @(link_name = "uv_req_get_type")
+    req_get_type :: proc(req: ^req_t) -> req_type ---
 
-	@(link_name = "uv_req_get_type")
-	req_get_type :: proc(req: ^uv_req_t) -> uv_req_type ---
+    @(link_name = "uv_req_type_name")
+    req_type_name :: proc(type: req_type) -> cstring ---
 
-	@(link_name = "uv_req_type_name")
-	req_type_name :: proc(type: uv_req_type) -> cstring ---
+    @(link_name = "uv_is_active")
+    is_active :: proc(handle: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_is_active")
-	is_active :: proc(handle: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_walk")
+    walk :: proc(loop: ^loop_t, walk_cb_p: walk_cb, arg: rawptr) ---
 
-	@(link_name = "uv_walk")
-	walk :: proc(loop: ^uv_loop_t, walk_cb: uv_walk_cb, arg: rawptr) ---
+    @(link_name = "uv_print_all_handles")
+    print_all_handles :: proc(loop: ^loop_t, stream: ^libc.FILE) ---
 
-	@(link_name = "uv_print_all_handles")
-	print_all_handles :: proc(loop: ^uv_loop_t, stream: ^FILE) ---
+    @(link_name = "uv_print_active_handles")
+    print_active_handles :: proc(loop: ^loop_t, stream: ^libc.FILE) ---
 
-	@(link_name = "uv_print_active_handles")
-	print_active_handles :: proc(loop: ^uv_loop_t, stream: ^FILE) ---
+    @(link_name = "uv_close")
+    close :: proc(handle: ^handle_t, close_cb_p: close_cb) ---
 
-	@(link_name = "uv_close")
-	close :: proc(handle: ^uv_handle_t, close_cb: uv_close_cb) ---
+    @(link_name = "uv_send_buffer_size")
+    send_buffer_size :: proc(handle: ^handle_t, value: ^i32) -> i32 ---
 
-	@(link_name = "uv_send_buffer_size")
-	send_buffer_size :: proc(handle: ^uv_handle_t, value: ^i32) -> i32 ---
+    @(link_name = "uv_recv_buffer_size")
+    recv_buffer_size :: proc(handle: ^handle_t, value: ^i32) -> i32 ---
 
-	@(link_name = "uv_recv_buffer_size")
-	recv_buffer_size :: proc(handle: ^uv_handle_t, value: ^i32) -> i32 ---
+    @(link_name = "uv_fileno")
+    fileno :: proc(handle: ^handle_t, fd: ^os_fd_t) -> i32 ---
 
-	@(link_name = "uv_fileno")
-	fileno :: proc(handle: ^uv_handle_t, fd: ^uv_os_fd_t) -> i32 ---
+    @(link_name = "uv_buf_init")
+    buf_init :: proc(base: cstring, len: u32) -> buf_t ---
 
-	@(link_name = "uv_buf_init")
-	buf_init :: proc(base: cstring, len: u32) -> uv_buf_t ---
+    @(link_name = "uv_pipe")
+    pipe :: proc(fds: [2]file, read_flags: i32, write_flags: i32) -> i32 ---
 
-	@(link_name = "uv_pipe")
-	pipe :: proc(fds: [2]uv_file, read_flags: i32, write_flags: i32) -> i32 ---
+    @(link_name = "uv_socketpair")
+    socketpair :: proc(type: i32, protocol: i32, socket_vector: [2]os_sock_t, flags0: i32, flags1: i32) -> i32 ---
 
-	@(link_name = "uv_socketpair")
-	socketpair :: proc(type: i32, protocol: i32, socket_vector: [2]uv_os_sock_t, flags0: i32, flags1: i32) -> i32 ---
+    @(link_name = "uv_stream_get_write_queue_size")
+    stream_get_write_queue_size :: proc(stream: ^stream_t) -> u64 ---
 
-	@(link_name = "uv_stream_get_write_queue_size")
-	stream_get_write_queue_size :: proc(stream: ^uv_stream_t) -> u64 ---
+    @(link_name = "uv_listen")
+    listen :: proc(stream: ^stream_t, backlog: i32, cb: connection_cb) -> i32 ---
 
-	@(link_name = "uv_listen")
-	listen :: proc(stream: ^uv_stream_t, backlog: i32, cb: uv_connection_cb) -> i32 ---
+    @(link_name = "uv_accept")
+    accept :: proc(server: ^stream_t, client: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_accept")
-	accept :: proc(server: ^uv_stream_t, client: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_read_start")
+    read_start :: proc(param0: ^stream_t, alloc_cb_p: alloc_cb, read_cb_p: read_cb) -> i32 ---
 
-	@(link_name = "uv_read_start")
-	read_start :: proc(param0: ^uv_stream_t, alloc_cb: uv_alloc_cb, read_cb: uv_read_cb) -> i32 ---
+    @(link_name = "uv_read_stop")
+    read_stop :: proc(param0: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_read_stop")
-	read_stop :: proc(param0: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_write")
+    write :: proc(req: ^write_t, handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, cb: write_cb) -> i32 ---
 
-	@(link_name = "uv_write")
-	write :: proc(req: ^uv_write_t, handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, cb: uv_write_cb) -> i32 ---
+    @(link_name = "uv_write2")
+    write2 :: proc(req: ^write_t, handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, send_handle: ^stream_t, cb: write_cb) -> i32 ---
 
-	@(link_name = "uv_write2")
-	write2 :: proc(req: ^uv_write_t, handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, send_handle: ^uv_stream_t, cb: uv_write_cb) -> i32 ---
+    @(link_name = "uv_try_write")
+    try_write :: proc(handle: ^stream_t, bufs: [^]buf_t, nbufs: u32) -> i32 ---
 
-	@(link_name = "uv_try_write")
-	try_write :: proc(handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32) -> i32 ---
+    @(link_name = "uv_try_write2")
+    try_write2 :: proc(handle: ^stream_t, bufs: [^]buf_t, nbufs: u32, send_handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_try_write2")
-	try_write2 :: proc(handle: ^uv_stream_t, bufs: [^]uv_buf_t, nbufs: u32, send_handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_is_readable")
+    is_readable :: proc(handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_is_readable")
-	is_readable :: proc(handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_is_writable")
+    is_writable :: proc(handle: ^stream_t) -> i32 ---
 
-	@(link_name = "uv_is_writable")
-	is_writable :: proc(handle: ^uv_stream_t) -> i32 ---
+    @(link_name = "uv_stream_set_blocking")
+    stream_set_blocking :: proc(handle: ^stream_t, blocking: i32) -> i32 ---
 
-	@(link_name = "uv_stream_set_blocking")
-	stream_set_blocking :: proc(handle: ^uv_stream_t, blocking: i32) -> i32 ---
+    @(link_name = "uv_is_closing")
+    is_closing :: proc(handle: ^handle_t) -> i32 ---
 
-	@(link_name = "uv_is_closing")
-	is_closing :: proc(handle: ^uv_handle_t) -> i32 ---
+    @(link_name = "uv_tcp_init")
+    tcp_init :: proc(param0: ^loop_t, handle: ^tcp_t) -> i32 ---
 
-	@(link_name = "uv_tcp_init")
-	tcp_init :: proc(param0: ^uv_loop_t, handle: ^uv_tcp_t) -> i32 ---
+    @(link_name = "uv_tcp_init_ex")
+    tcp_init_ex :: proc(param0: ^loop_t, handle: ^tcp_t, flags: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_init_ex")
-	tcp_init_ex :: proc(param0: ^uv_loop_t, handle: ^uv_tcp_t, flags: u32) -> i32 ---
+    @(link_name = "uv_tcp_open")
+    tcp_open :: proc(handle: ^tcp_t, sock: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_tcp_open")
-	tcp_open :: proc(handle: ^uv_tcp_t, sock: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_tcp_nodelay")
+    tcp_nodelay :: proc(handle: ^tcp_t, enable: i32) -> i32 ---
 
-	@(link_name = "uv_tcp_nodelay")
-	tcp_nodelay :: proc(handle: ^uv_tcp_t, enable: i32) -> i32 ---
+    @(link_name = "uv_tcp_keepalive")
+    tcp_keepalive :: proc(handle: ^tcp_t, enable: i32, delay: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_keepalive")
-	tcp_keepalive :: proc(handle: ^uv_tcp_t, enable: i32, delay: u32) -> i32 ---
+    @(link_name = "uv_tcp_simultaneous_accepts")
+    tcp_simultaneous_accepts :: proc(handle: ^tcp_t, enable: i32) -> i32 ---
 
-	@(link_name = "uv_tcp_simultaneous_accepts")
-	tcp_simultaneous_accepts :: proc(handle: ^uv_tcp_t, enable: i32) -> i32 ---
+    @(link_name = "uv_tcp_bind")
+    tcp_bind :: proc(handle: ^tcp_t, addr: ^posix.sockaddr, flags: u32) -> i32 ---
 
-	@(link_name = "uv_tcp_bind")
-	tcp_bind :: proc(handle: ^uv_tcp_t, addr: rawptr, flags: u32) -> i32 ---
+    @(link_name = "uv_tcp_getsockname")
+    tcp_getsockname :: proc(handle: ^tcp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_tcp_getsockname")
-	tcp_getsockname :: proc(handle: ^uv_tcp_t, name: rawptr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_tcp_getpeername")
+    tcp_getpeername :: proc(handle: ^tcp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_tcp_getpeername")
-	tcp_getpeername :: proc(handle: ^uv_tcp_t, name: rawptr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_tcp_close_reset")
+    tcp_close_reset :: proc(handle: ^tcp_t, close_cb_p: close_cb) -> i32 ---
 
-	@(link_name = "uv_tcp_close_reset")
-	tcp_close_reset :: proc(handle: ^uv_tcp_t, close_cb: uv_close_cb) -> i32 ---
+    @(link_name = "uv_tcp_connect")
+    tcp_connect :: proc(req: ^connect_t, handle: ^tcp_t, addr: ^posix.sockaddr, cb: connect_cb) -> i32 ---
 
-	@(link_name = "uv_tcp_connect")
-	tcp_connect :: proc(req: ^uv_connect_t, handle: ^uv_tcp_t, addr: rawptr, cb: uv_connect_cb) -> i32 ---
+    @(link_name = "uv_udp_init")
+    udp_init :: proc(param0: ^loop_t, handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_init")
-	udp_init :: proc(param0: ^uv_loop_t, handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_init_ex")
+    udp_init_ex :: proc(param0: ^loop_t, handle: ^udp_t, flags: u32) -> i32 ---
 
-	@(link_name = "uv_udp_init_ex")
-	udp_init_ex :: proc(param0: ^uv_loop_t, handle: ^uv_udp_t, flags: u32) -> i32 ---
+    @(link_name = "uv_udp_open")
+    udp_open :: proc(handle: ^udp_t, sock: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_udp_open")
-	udp_open :: proc(handle: ^uv_udp_t, sock: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_udp_bind")
+    udp_bind :: proc(handle: ^udp_t, addr: ^posix.sockaddr, flags: u32) -> i32 ---
 
-	@(link_name = "uv_udp_bind")
-	udp_bind :: proc(handle: ^uv_udp_t, addr: rawptr, flags: u32) -> i32 ---
+    @(link_name = "uv_udp_connect")
+    udp_connect :: proc(handle: ^udp_t, addr: ^posix.sockaddr) -> i32 ---
 
-	@(link_name = "uv_udp_connect")
-	udp_connect :: proc(handle: ^uv_udp_t, addr: rawptr) -> i32 ---
+    @(link_name = "uv_udp_getpeername")
+    udp_getpeername :: proc(handle: ^udp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_udp_getpeername")
-	udp_getpeername :: proc(handle: ^uv_udp_t, name: rawptr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_udp_getsockname")
+    udp_getsockname :: proc(handle: ^udp_t, name: ^posix.sockaddr, namelen: ^i32) -> i32 ---
 
-	@(link_name = "uv_udp_getsockname")
-	udp_getsockname :: proc(handle: ^uv_udp_t, name: rawptr, namelen: ^i32) -> i32 ---
+    @(link_name = "uv_udp_set_membership")
+    udp_set_membership :: proc(handle: ^udp_t, multicast_addr: cstring, interface_addr: cstring, membership_p: membership) -> i32 ---
 
-	@(link_name = "uv_udp_set_membership")
-	udp_set_membership :: proc(handle: ^uv_udp_t, multicast_addr: cstring, interface_addr: cstring, membership: uv_membership) -> i32 ---
+    @(link_name = "uv_udp_set_source_membership")
+    udp_set_source_membership :: proc(handle: ^udp_t, multicast_addr: cstring, interface_addr: cstring, source_addr: cstring, membership_p: membership) -> i32 ---
 
-	@(link_name = "uv_udp_set_source_membership")
-	udp_set_source_membership :: proc(handle: ^uv_udp_t, multicast_addr: cstring, interface_addr: cstring, source_addr: cstring, membership: uv_membership) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_loop")
+    udp_set_multicast_loop :: proc(handle: ^udp_t, on: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_loop")
-	udp_set_multicast_loop :: proc(handle: ^uv_udp_t, on: i32) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_ttl")
+    udp_set_multicast_ttl :: proc(handle: ^udp_t, ttl: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_ttl")
-	udp_set_multicast_ttl :: proc(handle: ^uv_udp_t, ttl: i32) -> i32 ---
+    @(link_name = "uv_udp_set_multicast_interface")
+    udp_set_multicast_interface :: proc(handle: ^udp_t, interface_addr: cstring) -> i32 ---
 
-	@(link_name = "uv_udp_set_multicast_interface")
-	udp_set_multicast_interface :: proc(handle: ^uv_udp_t, interface_addr: cstring) -> i32 ---
+    @(link_name = "uv_udp_set_broadcast")
+    udp_set_broadcast :: proc(handle: ^udp_t, on: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_broadcast")
-	udp_set_broadcast :: proc(handle: ^uv_udp_t, on: i32) -> i32 ---
+    @(link_name = "uv_udp_set_ttl")
+    udp_set_ttl :: proc(handle: ^udp_t, ttl: i32) -> i32 ---
 
-	@(link_name = "uv_udp_set_ttl")
-	udp_set_ttl :: proc(handle: ^uv_udp_t, ttl: i32) -> i32 ---
+    @(link_name = "uv_udp_send")
+    udp_send :: proc(req: ^udp_send_t, handle: ^udp_t, bufs: [^]buf_t, nbufs: u32, addr: ^posix.sockaddr, send_cb: udp_send_cb) -> i32 ---
 
-	@(link_name = "uv_udp_send")
-	udp_send :: proc(req: ^uv_udp_send_t, handle: ^uv_udp_t, bufs: [^]uv_buf_t, nbufs: u32, addr: rawptr, send_cb: uv_udp_send_cb) -> i32 ---
+    @(link_name = "uv_udp_try_send")
+    udp_try_send :: proc(handle: ^udp_t, bufs: [^]buf_t, nbufs: u32, addr: ^posix.sockaddr) -> i32 ---
 
-	@(link_name = "uv_udp_try_send")
-	udp_try_send :: proc(handle: ^uv_udp_t, bufs: [^]uv_buf_t, nbufs: u32, addr: rawptr) -> i32 ---
+    @(link_name = "uv_udp_recv_start")
+    udp_recv_start :: proc(handle: ^udp_t, alloc_cb_p: alloc_cb, recv_cb: udp_recv_cb) -> i32 ---
 
-	@(link_name = "uv_udp_recv_start")
-	udp_recv_start :: proc(handle: ^uv_udp_t, alloc_cb: uv_alloc_cb, recv_cb: uv_udp_recv_cb) -> i32 ---
+    @(link_name = "uv_udp_using_recvmmsg")
+    udp_using_recvmmsg :: proc(handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_using_recvmmsg")
-	udp_using_recvmmsg :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_recv_stop")
+    udp_recv_stop :: proc(handle: ^udp_t) -> i32 ---
 
-	@(link_name = "uv_udp_recv_stop")
-	udp_recv_stop :: proc(handle: ^uv_udp_t) -> i32 ---
+    @(link_name = "uv_udp_get_send_queue_size")
+    udp_get_send_queue_size :: proc(handle: ^udp_t) -> u64 ---
 
-	@(link_name = "uv_udp_get_send_queue_size")
-	udp_get_send_queue_size :: proc(handle: ^uv_udp_t) -> u64 ---
+    @(link_name = "uv_udp_get_send_queue_count")
+    udp_get_send_queue_count :: proc(handle: ^udp_t) -> u64 ---
 
-	@(link_name = "uv_udp_get_send_queue_count")
-	udp_get_send_queue_count :: proc(handle: ^uv_udp_t) -> u64 ---
+    @(link_name = "uv_tty_init")
+    tty_init :: proc(param0: ^loop_t, param1: ^tty_t, fd: file, readable: i32) -> i32 ---
 
-	@(link_name = "uv_tty_init")
-	tty_init :: proc(param0: ^uv_loop_t, param1: ^uv_tty_t, fd: uv_file, readable: i32) -> i32 ---
+    @(link_name = "uv_tty_set_mode")
+    tty_set_mode :: proc(param0: ^tty_t, mode: tty_mode_t) -> i32 ---
 
-	@(link_name = "uv_tty_set_mode")
-	tty_set_mode :: proc(param0: ^uv_tty_t, mode: uv_tty_mode_t) -> i32 ---
+    @(link_name = "uv_tty_reset_mode")
+    tty_reset_mode :: proc() -> i32 ---
 
-	@(link_name = "uv_tty_reset_mode")
-	tty_reset_mode :: proc() -> i32 ---
+    @(link_name = "uv_tty_get_winsize")
+    tty_get_winsize :: proc(param0: ^tty_t, width: ^i32, height: ^i32) -> i32 ---
 
-	@(link_name = "uv_tty_get_winsize")
-	tty_get_winsize :: proc(param0: ^uv_tty_t, width: ^i32, height: ^i32) -> i32 ---
+    @(link_name = "uv_tty_set_vterm_state")
+    tty_set_vterm_state :: proc(state: tty_vtermstate_t) ---
 
-	@(link_name = "uv_tty_set_vterm_state")
-	tty_set_vterm_state :: proc(state: uv_tty_vtermstate_t) ---
+    @(link_name = "uv_tty_get_vterm_state")
+    tty_get_vterm_state :: proc(state: ^tty_vtermstate_t) -> i32 ---
 
-	@(link_name = "uv_tty_get_vterm_state")
-	tty_get_vterm_state :: proc(state: ^uv_tty_vtermstate_t) -> i32 ---
+    @(link_name = "uv_guess_handle")
+    guess_handle :: proc(file_p: file) -> handle_type ---
 
-	@(link_name = "uv_guess_handle")
-	guess_handle :: proc(file: uv_file) -> uv_handle_type ---
+    @(link_name = "uv_pipe_init")
+    pipe_init :: proc(param0: ^loop_t, handle: ^pipe_t, ipc: i32) -> i32 ---
 
-	@(link_name = "uv_pipe_init")
-	pipe_init :: proc(param0: ^uv_loop_t, handle: ^uv_pipe_t, ipc: i32) -> i32 ---
+    @(link_name = "uv_pipe_open")
+    pipe_open :: proc(param0: ^pipe_t, file_p: file) -> i32 ---
 
-	@(link_name = "uv_pipe_open")
-	pipe_open :: proc(param0: ^uv_pipe_t, file: uv_file) -> i32 ---
+    @(link_name = "uv_pipe_bind")
+    pipe_bind :: proc(handle: ^pipe_t, name: cstring) -> i32 ---
 
-	@(link_name = "uv_pipe_bind")
-	pipe_bind :: proc(handle: ^uv_pipe_t, name: cstring) -> i32 ---
+    @(link_name = "uv_pipe_bind2")
+    pipe_bind2 :: proc(handle: ^pipe_t, name: cstring, namelen: u64, flags: u32) -> i32 ---
 
-	@(link_name = "uv_pipe_bind2")
-	pipe_bind2 :: proc(handle: ^uv_pipe_t, name: cstring, namelen: u64, flags: u32) -> i32 ---
+    @(link_name = "uv_pipe_connect")
+    pipe_connect :: proc(req: ^connect_t, handle: ^pipe_t, name: cstring, cb: connect_cb) ---
 
-	@(link_name = "uv_pipe_connect")
-	pipe_connect :: proc(req: ^uv_connect_t, handle: ^uv_pipe_t, name: cstring, cb: uv_connect_cb) ---
+    @(link_name = "uv_pipe_connect2")
+    pipe_connect2 :: proc(req: ^connect_t, handle: ^pipe_t, name: cstring, namelen: u64, flags: u32, cb: connect_cb) -> i32 ---
 
-	@(link_name = "uv_pipe_connect2")
-	pipe_connect2 :: proc(req: ^uv_connect_t, handle: ^uv_pipe_t, name: cstring, namelen: u64, flags: u32, cb: uv_connect_cb) -> i32 ---
+    @(link_name = "uv_pipe_getsockname")
+    pipe_getsockname :: proc(handle: ^pipe_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_pipe_getsockname")
-	pipe_getsockname :: proc(handle: ^uv_pipe_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_pipe_getpeername")
+    pipe_getpeername :: proc(handle: ^pipe_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_pipe_getpeername")
-	pipe_getpeername :: proc(handle: ^uv_pipe_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_pipe_pending_instances")
+    pipe_pending_instances :: proc(handle: ^pipe_t, count: i32) ---
 
-	@(link_name = "uv_pipe_pending_instances")
-	pipe_pending_instances :: proc(handle: ^uv_pipe_t, count: i32) ---
+    @(link_name = "uv_pipe_pending_count")
+    pipe_pending_count :: proc(handle: ^pipe_t) -> i32 ---
 
-	@(link_name = "uv_pipe_pending_count")
-	pipe_pending_count :: proc(handle: ^uv_pipe_t) -> i32 ---
+    @(link_name = "uv_pipe_pending_type")
+    pipe_pending_type :: proc(handle: ^pipe_t) -> handle_type ---
 
-	@(link_name = "uv_pipe_pending_type")
-	pipe_pending_type :: proc(handle: ^uv_pipe_t) -> uv_handle_type ---
+    @(link_name = "uv_pipe_chmod")
+    pipe_chmod :: proc(handle: ^pipe_t, flags: i32) -> i32 ---
 
-	@(link_name = "uv_pipe_chmod")
-	pipe_chmod :: proc(handle: ^uv_pipe_t, flags: i32) -> i32 ---
+    @(link_name = "uv_poll_init")
+    poll_init :: proc(loop: ^loop_t, handle: ^poll_t, fd: i32) -> i32 ---
 
-	@(link_name = "uv_poll_init")
-	poll_init :: proc(loop: ^uv_loop_t, handle: ^uv_poll_t, fd: i32) -> i32 ---
+    @(link_name = "uv_poll_init_socket")
+    poll_init_socket :: proc(loop: ^loop_t, handle: ^poll_t, socket: os_sock_t) -> i32 ---
 
-	@(link_name = "uv_poll_init_socket")
-	poll_init_socket :: proc(loop: ^uv_loop_t, handle: ^uv_poll_t, socket: uv_os_sock_t) -> i32 ---
+    @(link_name = "uv_poll_start")
+    poll_start :: proc(handle: ^poll_t, events: i32, cb: poll_cb) -> i32 ---
 
-	@(link_name = "uv_poll_start")
-	poll_start :: proc(handle: ^uv_poll_t, events: i32, cb: uv_poll_cb) -> i32 ---
+    @(link_name = "uv_poll_stop")
+    poll_stop :: proc(handle: ^poll_t) -> i32 ---
 
-	@(link_name = "uv_poll_stop")
-	poll_stop :: proc(handle: ^uv_poll_t) -> i32 ---
+    @(link_name = "uv_prepare_init")
+    prepare_init :: proc(param0: ^loop_t, prepare: ^prepare_t) -> i32 ---
 
-	@(link_name = "uv_prepare_init")
-	prepare_init :: proc(param0: ^uv_loop_t, prepare: ^uv_prepare_t) -> i32 ---
+    @(link_name = "uv_prepare_start")
+    prepare_start :: proc(prepare: ^prepare_t, cb: prepare_cb) -> i32 ---
 
-	@(link_name = "uv_prepare_start")
-	prepare_start :: proc(prepare: ^uv_prepare_t, cb: uv_prepare_cb) -> i32 ---
+    @(link_name = "uv_prepare_stop")
+    prepare_stop :: proc(prepare: ^prepare_t) -> i32 ---
 
-	@(link_name = "uv_prepare_stop")
-	prepare_stop :: proc(prepare: ^uv_prepare_t) -> i32 ---
+    @(link_name = "uv_check_init")
+    check_init :: proc(param0: ^loop_t, check: ^check_t) -> i32 ---
 
-	@(link_name = "uv_check_init")
-	check_init :: proc(param0: ^uv_loop_t, check: ^uv_check_t) -> i32 ---
+    @(link_name = "uv_check_start")
+    check_start :: proc(check: ^check_t, cb: check_cb) -> i32 ---
 
-	@(link_name = "uv_check_start")
-	check_start :: proc(check: ^uv_check_t, cb: uv_check_cb) -> i32 ---
+    @(link_name = "uv_check_stop")
+    check_stop :: proc(check: ^check_t) -> i32 ---
 
-	@(link_name = "uv_check_stop")
-	check_stop :: proc(check: ^uv_check_t) -> i32 ---
+    @(link_name = "uv_idle_init")
+    idle_init :: proc(param0: ^loop_t, idle: ^idle_t) -> i32 ---
 
-	@(link_name = "uv_idle_init")
-	idle_init :: proc(param0: ^uv_loop_t, idle: ^uv_idle_t) -> i32 ---
+    @(link_name = "uv_idle_start")
+    idle_start :: proc(idle: ^idle_t, cb: idle_cb) -> i32 ---
 
-	@(link_name = "uv_idle_start")
-	idle_start :: proc(idle: ^uv_idle_t, cb: uv_idle_cb) -> i32 ---
+    @(link_name = "uv_idle_stop")
+    idle_stop :: proc(idle: ^idle_t) -> i32 ---
 
-	@(link_name = "uv_idle_stop")
-	idle_stop :: proc(idle: ^uv_idle_t) -> i32 ---
+    @(link_name = "uv_async_init")
+    async_init :: proc(param0: ^loop_t, async: ^async_t, async_cb_p: async_cb) -> i32 ---
 
-	@(link_name = "uv_async_init")
-	async_init :: proc(param0: ^uv_loop_t, async: ^uv_async_t, async_cb: uv_async_cb) -> i32 ---
+    @(link_name = "uv_async_send")
+    async_send :: proc(async: ^async_t) -> i32 ---
 
-	@(link_name = "uv_async_send")
-	async_send :: proc(async: ^uv_async_t) -> i32 ---
+    @(link_name = "uv_timer_init")
+    timer_init :: proc(param0: ^loop_t, handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_init")
-	timer_init :: proc(param0: ^uv_loop_t, handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_start")
+    timer_start :: proc(handle: ^timer_t, cb: timer_cb, timeout: u64, repeat: u64) -> i32 ---
 
-	@(link_name = "uv_timer_start")
-	timer_start :: proc(handle: ^uv_timer_t, cb: uv_timer_cb, timeout: u64, repeat: u64) -> i32 ---
+    @(link_name = "uv_timer_stop")
+    timer_stop :: proc(handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_stop")
-	timer_stop :: proc(handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_again")
+    timer_again :: proc(handle: ^timer_t) -> i32 ---
 
-	@(link_name = "uv_timer_again")
-	timer_again :: proc(handle: ^uv_timer_t) -> i32 ---
+    @(link_name = "uv_timer_set_repeat")
+    timer_set_repeat :: proc(handle: ^timer_t, repeat: u64) ---
 
-	@(link_name = "uv_timer_set_repeat")
-	timer_set_repeat :: proc(handle: ^uv_timer_t, repeat: u64) ---
+    @(link_name = "uv_timer_get_repeat")
+    timer_get_repeat :: proc(handle: ^timer_t) -> u64 ---
 
-	@(link_name = "uv_timer_get_repeat")
-	timer_get_repeat :: proc(handle: ^uv_timer_t) -> u64 ---
+    @(link_name = "uv_timer_get_due_in")
+    timer_get_due_in :: proc(handle: ^timer_t) -> u64 ---
 
-	@(link_name = "uv_timer_get_due_in")
-	timer_get_due_in :: proc(handle: ^uv_timer_t) -> u64 ---
+    @(link_name = "uv_getaddrinfo")
+    getaddrinfo :: proc(loop: ^loop_t, req: ^getaddrinfo_t, getaddrinfo_cb_p: getaddrinfo_cb, node: cstring, service: cstring, hints: [^]posix.addrinfo) -> i32 ---
 
-	@(link_name = "uv_getaddrinfo")
-	getaddrinfo :: proc(loop: ^uv_loop_t, req: ^uv_getaddrinfo_t, getaddrinfo_cb: uv_getaddrinfo_cb, node: cstring, service: cstring, hints: [^]addrinfo) -> i32 ---
+    @(link_name = "uv_freeaddrinfo")
+    freeaddrinfo :: proc(ai: ^posix.addrinfo) ---
 
-	@(link_name = "uv_freeaddrinfo")
-	freeaddrinfo :: proc(ai: ^addrinfo) ---
+    @(link_name = "uv_getnameinfo")
+    getnameinfo :: proc(loop: ^loop_t, req: ^getnameinfo_t, getnameinfo_cb_p: getnameinfo_cb, addr: ^posix.sockaddr, flags: i32) -> i32 ---
 
-	@(link_name = "uv_getnameinfo")
-	getnameinfo :: proc(loop: ^uv_loop_t, req: ^uv_getnameinfo_t, getnameinfo_cb: uv_getnameinfo_cb, addr: rawptr, flags: i32) -> i32 ---
+    @(link_name = "uv_spawn")
+    spawn :: proc(loop: ^loop_t, handle: ^process_t, options: [^]process_options_t) -> i32 ---
 
-	@(link_name = "uv_spawn")
-	spawn :: proc(loop: ^uv_loop_t, handle: ^uv_process_t, options: [^]uv_process_options_t) -> i32 ---
+    @(link_name = "uv_process_kill")
+    process_kill :: proc(param0: ^process_t, signum: i32) -> i32 ---
 
-	@(link_name = "uv_process_kill")
-	process_kill :: proc(param0: ^uv_process_t, signum: i32) -> i32 ---
+    @(link_name = "uv_kill")
+    kill :: proc(pid: i32, signum: i32) -> i32 ---
 
-	@(link_name = "uv_kill")
-	kill :: proc(pid: i32, signum: i32) -> i32 ---
+    @(link_name = "uv_process_get_pid")
+    process_get_pid :: proc(param0: ^process_t) -> pid_t ---
 
-	@(link_name = "uv_process_get_pid")
-	process_get_pid :: proc(param0: ^uv_process_t) -> uv_pid_t ---
+    @(link_name = "uv_queue_work")
+    queue_work :: proc(loop: ^loop_t, req: ^work_t, work_cb_p: work_cb, after_work_cb_p: after_work_cb) -> i32 ---
 
-	@(link_name = "uv_queue_work")
-	queue_work :: proc(loop: ^uv_loop_t, req: ^uv_work_t, work_cb: uv_work_cb, after_work_cb: uv_after_work_cb) -> i32 ---
+    @(link_name = "uv_cancel")
+    cancel :: proc(req: ^req_t) -> i32 ---
 
-	@(link_name = "uv_cancel")
-	cancel :: proc(req: ^uv_req_t) -> i32 ---
+    @(link_name = "uv_setup_args")
+    setup_args :: proc(argc: i32, argv: ^cstring) -> ^cstring ---
 
-	@(link_name = "uv_setup_args")
-	setup_args :: proc(argc: i32, argv: ^cstring) -> ^cstring ---
+    @(link_name = "uv_get_process_title")
+    get_process_title :: proc(buffer: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_get_process_title")
-	get_process_title :: proc(buffer: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_set_process_title")
+    set_process_title :: proc(title: cstring) -> i32 ---
 
-	@(link_name = "uv_set_process_title")
-	set_process_title :: proc(title: cstring) -> i32 ---
+    @(link_name = "uv_resident_set_memory")
+    resident_set_memory :: proc(rss: [^]u64) -> i32 ---
 
-	@(link_name = "uv_resident_set_memory")
-	resident_set_memory :: proc(rss: [^]u64) -> i32 ---
+    @(link_name = "uv_uptime")
+    uptime :: proc(uptime: ^f64) -> i32 ---
 
-	@(link_name = "uv_uptime")
-	uptime :: proc(uptime: ^f64) -> i32 ---
+    @(link_name = "uv_get_osfhandle")
+    get_osfhandle :: proc(fd: i32) -> os_fd_t ---
 
-	@(link_name = "uv_get_osfhandle")
-	get_osfhandle :: proc(fd: i32) -> uv_os_fd_t ---
+    @(link_name = "uv_open_osfhandle")
+    open_osfhandle :: proc(os_fd: os_fd_t) -> i32 ---
 
-	@(link_name = "uv_open_osfhandle")
-	open_osfhandle :: proc(os_fd: uv_os_fd_t) -> i32 ---
+    @(link_name = "uv_getrusage")
+    getrusage :: proc(rusage: ^rusage_t) -> i32 ---
 
-	@(link_name = "uv_getrusage")
-	getrusage :: proc(rusage: ^uv_rusage_t) -> i32 ---
+    @(link_name = "uv_os_homedir")
+    os_homedir :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_homedir")
-	os_homedir :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_tmpdir")
+    os_tmpdir :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_tmpdir")
-	os_tmpdir :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_get_passwd")
+    os_get_passwd :: proc(pwd: ^passwd_t) -> i32 ---
 
-	@(link_name = "uv_os_get_passwd")
-	os_get_passwd :: proc(pwd: ^uv_passwd_t) -> i32 ---
+    @(link_name = "uv_os_free_passwd")
+    os_free_passwd :: proc(pwd: ^passwd_t) ---
 
-	@(link_name = "uv_os_free_passwd")
-	os_free_passwd :: proc(pwd: ^uv_passwd_t) ---
+    @(link_name = "uv_os_get_passwd2")
+    os_get_passwd2 :: proc(pwd: ^passwd_t, uid: uid_t) -> i32 ---
 
-	@(link_name = "uv_os_get_passwd2")
-	os_get_passwd2 :: proc(pwd: ^uv_passwd_t, uid: uv_uid_t) -> i32 ---
+    @(link_name = "uv_os_get_group")
+    os_get_group :: proc(grp: ^group_t, gid: uid_t) -> i32 ---
 
-	@(link_name = "uv_os_get_group")
-	os_get_group :: proc(grp: ^uv_group_t, gid: uv_uid_t) -> i32 ---
+    @(link_name = "uv_os_free_group")
+    os_free_group :: proc(grp: ^group_t) ---
 
-	@(link_name = "uv_os_free_group")
-	os_free_group :: proc(grp: ^uv_group_t) ---
+    @(link_name = "uv_os_getpid")
+    os_getpid :: proc() -> pid_t ---
 
-	@(link_name = "uv_os_getpid")
-	os_getpid :: proc() -> uv_pid_t ---
+    @(link_name = "uv_os_getppid")
+    os_getppid :: proc() -> pid_t ---
 
-	@(link_name = "uv_os_getppid")
-	os_getppid :: proc() -> uv_pid_t ---
+    @(link_name = "uv_os_getpriority")
+    os_getpriority :: proc(pid: pid_t, priority: ^i32) -> i32 ---
 
-	@(link_name = "uv_os_getpriority")
-	os_getpriority :: proc(pid: uv_pid_t, priority: ^i32) -> i32 ---
+    @(link_name = "uv_os_setpriority")
+    os_setpriority :: proc(pid: pid_t, priority: i32) -> i32 ---
 
-	@(link_name = "uv_os_setpriority")
-	os_setpriority :: proc(pid: uv_pid_t, priority: i32) -> i32 ---
+    @(link_name = "uv_thread_getpriority")
+    thread_getpriority :: proc(tid: thread_t, priority: ^i32) -> i32 ---
 
-	@(link_name = "uv_thread_getpriority")
-	thread_getpriority :: proc(tid: uv_thread_t, priority: ^i32) -> i32 ---
+    @(link_name = "uv_thread_setpriority")
+    thread_setpriority :: proc(tid: thread_t, priority: i32) -> i32 ---
 
-	@(link_name = "uv_thread_setpriority")
-	thread_setpriority :: proc(tid: uv_thread_t, priority: i32) -> i32 ---
+    @(link_name = "uv_available_parallelism")
+    available_parallelism :: proc() -> u32 ---
 
-	@(link_name = "uv_available_parallelism")
-	available_parallelism :: proc() -> u32 ---
+    @(link_name = "uv_cpu_info")
+    cpu_info :: proc(cpu_infos: ^[^]cpu_info_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_cpu_info")
-	cpu_info :: proc(cpu_infos: ^[^]uv_cpu_info_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_free_cpu_info")
+    free_cpu_info :: proc(cpu_infos: [^]cpu_info_t, count: i32) ---
 
-	@(link_name = "uv_free_cpu_info")
-	free_cpu_info :: proc(cpu_infos: [^]uv_cpu_info_t, count: i32) ---
+    @(link_name = "uv_cpumask_size")
+    cpumask_size :: proc() -> i32 ---
 
-	@(link_name = "uv_cpumask_size")
-	cpumask_size :: proc() -> i32 ---
+    @(link_name = "uv_interface_addresses")
+    interface_addresses :: proc(addresses: ^[^]interface_address_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_interface_addresses")
-	interface_addresses :: proc(addresses: ^[^]uv_interface_address_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_free_interface_addresses")
+    free_interface_addresses :: proc(addresses: [^]interface_address_t, count: i32) ---
 
-	@(link_name = "uv_free_interface_addresses")
-	free_interface_addresses :: proc(addresses: [^]uv_interface_address_t, count: i32) ---
+    @(link_name = "uv_os_environ")
+    os_environ :: proc(envitems: ^[^]env_item_t, count: ^i32) -> i32 ---
 
-	@(link_name = "uv_os_environ")
-	os_environ :: proc(envitems: ^[^]uv_env_item_t, count: ^i32) -> i32 ---
+    @(link_name = "uv_os_free_environ")
+    os_free_environ :: proc(envitems: [^]env_item_t, count: i32) ---
 
-	@(link_name = "uv_os_free_environ")
-	os_free_environ :: proc(envitems: [^]uv_env_item_t, count: i32) ---
+    @(link_name = "uv_os_getenv")
+    os_getenv :: proc(name: cstring, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_getenv")
-	os_getenv :: proc(name: cstring, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_setenv")
+    os_setenv :: proc(name: cstring, value: cstring) -> i32 ---
 
-	@(link_name = "uv_os_setenv")
-	os_setenv :: proc(name: cstring, value: cstring) -> i32 ---
+    @(link_name = "uv_os_unsetenv")
+    os_unsetenv :: proc(name: cstring) -> i32 ---
 
-	@(link_name = "uv_os_unsetenv")
-	os_unsetenv :: proc(name: cstring) -> i32 ---
+    @(link_name = "uv_os_gethostname")
+    os_gethostname :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_os_gethostname")
-	os_gethostname :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_os_uname")
+    os_uname :: proc(buffer: ^utsname_t) -> i32 ---
 
-	@(link_name = "uv_os_uname")
-	os_uname :: proc(buffer: ^uv_utsname_t) -> i32 ---
+    @(link_name = "uv_metrics_info")
+    metrics_info :: proc(loop: ^loop_t, metrics: [^]metrics_t) -> i32 ---
 
-	@(link_name = "uv_metrics_info")
-	metrics_info :: proc(loop: ^uv_loop_t, metrics: [^]uv_metrics_t) -> i32 ---
+    @(link_name = "uv_metrics_idle_time")
+    metrics_idle_time :: proc(loop: ^loop_t) -> u64 ---
 
-	@(link_name = "uv_metrics_idle_time")
-	metrics_idle_time :: proc(loop: ^uv_loop_t) -> u64 ---
+    @(link_name = "uv_fs_get_type")
+    fs_get_type :: proc(param0: ^fs_t) -> fs_type ---
 
-	@(link_name = "uv_fs_get_type")
-	fs_get_type :: proc(param0: ^uv_fs_t) -> uv_fs_type ---
+    @(link_name = "uv_fs_get_result")
+    fs_get_result :: proc(param0: ^fs_t) -> i64 ---
 
-	@(link_name = "uv_fs_get_result")
-	fs_get_result :: proc(param0: ^uv_fs_t) -> ssize_t ---
+    @(link_name = "uv_fs_get_system_error")
+    fs_get_system_error :: proc(param0: ^fs_t) -> i32 ---
 
-	@(link_name = "uv_fs_get_system_error")
-	fs_get_system_error :: proc(param0: ^uv_fs_t) -> i32 ---
+    @(link_name = "uv_fs_get_ptr")
+    fs_get_ptr :: proc(param0: ^fs_t) -> rawptr ---
 
-	@(link_name = "uv_fs_get_ptr")
-	fs_get_ptr :: proc(param0: ^uv_fs_t) -> rawptr ---
+    @(link_name = "uv_fs_get_path")
+    fs_get_path :: proc(param0: ^fs_t) -> cstring ---
 
-	@(link_name = "uv_fs_get_path")
-	fs_get_path :: proc(param0: ^uv_fs_t) -> cstring ---
+    @(link_name = "uv_fs_get_statbuf")
+    fs_get_statbuf :: proc(param0: ^fs_t) -> ^stat_t ---
 
-	@(link_name = "uv_fs_get_statbuf")
-	fs_get_statbuf :: proc(param0: ^uv_fs_t) -> ^uv_stat_t ---
+    @(link_name = "uv_fs_req_cleanup")
+    fs_req_cleanup :: proc(req: ^fs_t) ---
 
-	@(link_name = "uv_fs_req_cleanup")
-	fs_req_cleanup :: proc(req: ^uv_fs_t) ---
+    @(link_name = "uv_fs_close")
+    fs_close :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_close")
-	fs_close :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_open")
+    fs_open :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, flags: i32, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_open")
-	fs_open :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, flags: i32, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_read")
+    fs_read :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, bufs: [^]buf_t, nbufs: u32, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_read")
-	fs_read :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, bufs: [^]uv_buf_t, nbufs: u32, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_unlink")
+    fs_unlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_unlink")
-	fs_unlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_write")
+    fs_write :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, bufs: [^]buf_t, nbufs: u32, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_write")
-	fs_write :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, bufs: [^]uv_buf_t, nbufs: u32, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_copyfile")
+    fs_copyfile :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_copyfile")
-	fs_copyfile :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkdir")
+    fs_mkdir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkdir")
-	fs_mkdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkdtemp")
+    fs_mkdtemp :: proc(loop: ^loop_t, req: ^fs_t, tpl: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkdtemp")
-	fs_mkdtemp :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, tpl: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_mkstemp")
+    fs_mkstemp :: proc(loop: ^loop_t, req: ^fs_t, tpl: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_mkstemp")
-	fs_mkstemp :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, tpl: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_rmdir")
+    fs_rmdir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_rmdir")
-	fs_rmdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_scandir")
+    fs_scandir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_scandir")
-	fs_scandir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_scandir_next")
+    fs_scandir_next :: proc(req: ^fs_t, ent: ^dirent_t) -> i32 ---
 
-	@(link_name = "uv_fs_scandir_next")
-	fs_scandir_next :: proc(req: ^uv_fs_t, ent: ^uv_dirent_t) -> i32 ---
+    @(link_name = "uv_fs_opendir")
+    fs_opendir :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_opendir")
-	fs_opendir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_readdir")
+    fs_readdir :: proc(loop: ^loop_t, req: ^fs_t, dir: ^dir_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_readdir")
-	fs_readdir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, dir: ^uv_dir_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_closedir")
+    fs_closedir :: proc(loop: ^loop_t, req: ^fs_t, dir: ^dir_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_closedir")
-	fs_closedir :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, dir: ^uv_dir_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_stat")
+    fs_stat :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_stat")
-	fs_stat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fstat")
+    fs_fstat :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fstat")
-	fs_fstat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_rename")
+    fs_rename :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_rename")
-	fs_rename :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fsync")
+    fs_fsync :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fsync")
-	fs_fsync :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fdatasync")
+    fs_fdatasync :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fdatasync")
-	fs_fdatasync :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_ftruncate")
+    fs_ftruncate :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, offset: i64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_ftruncate")
-	fs_ftruncate :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, offset: i64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_sendfile")
+    fs_sendfile :: proc(loop: ^loop_t, req: ^fs_t, out_fd: file, in_fd: file, in_offset: i64, length: u64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_sendfile")
-	fs_sendfile :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, out_fd: uv_file, in_fd: uv_file, in_offset: i64, length: u64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_access")
+    fs_access :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_access")
-	fs_access :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_chmod")
+    fs_chmod :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_chmod")
-	fs_chmod :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_utime")
+    fs_utime :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_utime")
-	fs_utime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_futime")
+    fs_futime :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_futime")
-	fs_futime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lutime")
+    fs_lutime :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, atime: f64, mtime: f64, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lutime")
-	fs_lutime :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, atime: f64, mtime: f64, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lstat")
+    fs_lstat :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lstat")
-	fs_lstat :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_link")
+    fs_link :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_link")
-	fs_link :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_symlink")
+    fs_symlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, new_path: cstring, flags: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_symlink")
-	fs_symlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, new_path: cstring, flags: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_readlink")
+    fs_readlink :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_readlink")
-	fs_readlink :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_realpath")
+    fs_realpath :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_realpath")
-	fs_realpath :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fchmod")
+    fs_fchmod :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, mode: i32, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fchmod")
-	fs_fchmod :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, mode: i32, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_chown")
+    fs_chown :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_chown")
-	fs_chown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_fchown")
+    fs_fchown :: proc(loop: ^loop_t, req: ^fs_t, file_p: file, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_fchown")
-	fs_fchown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, file: uv_file, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_lchown")
+    fs_lchown :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, uid: uid_t, gid: gid_t, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_lchown")
-	fs_lchown :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, uid: uv_uid_t, gid: uv_gid_t, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_statfs")
+    fs_statfs :: proc(loop: ^loop_t, req: ^fs_t, path: cstring, cb: fs_cb) -> i32 ---
 
-	@(link_name = "uv_fs_statfs")
-	fs_statfs :: proc(loop: ^uv_loop_t, req: ^uv_fs_t, path: cstring, cb: uv_fs_cb) -> i32 ---
+    @(link_name = "uv_fs_poll_init")
+    fs_poll_init :: proc(loop: ^loop_t, handle: ^fs_poll_t) -> i32 ---
 
-	@(link_name = "uv_fs_poll_init")
-	fs_poll_init :: proc(loop: ^uv_loop_t, handle: ^uv_fs_poll_t) -> i32 ---
+    @(link_name = "uv_fs_poll_start")
+    fs_poll_start :: proc(handle: ^fs_poll_t, poll_cb_p: fs_poll_cb, path: cstring, interval: u32) -> i32 ---
 
-	@(link_name = "uv_fs_poll_start")
-	fs_poll_start :: proc(handle: ^uv_fs_poll_t, poll_cb: uv_fs_poll_cb, path: cstring, interval: u32) -> i32 ---
+    @(link_name = "uv_fs_poll_stop")
+    fs_poll_stop :: proc(handle: ^fs_poll_t) -> i32 ---
 
-	@(link_name = "uv_fs_poll_stop")
-	fs_poll_stop :: proc(handle: ^uv_fs_poll_t) -> i32 ---
+    @(link_name = "uv_fs_poll_getpath")
+    fs_poll_getpath :: proc(handle: ^fs_poll_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_fs_poll_getpath")
-	fs_poll_getpath :: proc(handle: ^uv_fs_poll_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_signal_init")
+    signal_init :: proc(loop: ^loop_t, handle: ^signal_t) -> i32 ---
 
-	@(link_name = "uv_signal_init")
-	signal_init :: proc(loop: ^uv_loop_t, handle: ^uv_signal_t) -> i32 ---
+    @(link_name = "uv_signal_start")
+    signal_start :: proc(handle: ^signal_t, signal_cb_p: signal_cb, signum: i32) -> i32 ---
 
-	@(link_name = "uv_signal_start")
-	signal_start :: proc(handle: ^uv_signal_t, signal_cb: uv_signal_cb, signum: i32) -> i32 ---
+    @(link_name = "uv_signal_start_oneshot")
+    signal_start_oneshot :: proc(handle: ^signal_t, signal_cb_p: signal_cb, signum: i32) -> i32 ---
 
-	@(link_name = "uv_signal_start_oneshot")
-	signal_start_oneshot :: proc(handle: ^uv_signal_t, signal_cb: uv_signal_cb, signum: i32) -> i32 ---
+    @(link_name = "uv_signal_stop")
+    signal_stop :: proc(handle: ^signal_t) -> i32 ---
 
-	@(link_name = "uv_signal_stop")
-	signal_stop :: proc(handle: ^uv_signal_t) -> i32 ---
+    @(link_name = "uv_loadavg")
+    loadavg :: proc(avg: [3]f64) ---
 
-	@(link_name = "uv_loadavg")
-	loadavg :: proc(avg: [3]f64) ---
+    @(link_name = "uv_fs_event_init")
+    fs_event_init :: proc(loop: ^loop_t, handle: ^fs_event_t) -> i32 ---
 
-	@(link_name = "uv_fs_event_init")
-	fs_event_init :: proc(loop: ^uv_loop_t, handle: ^uv_fs_event_t) -> i32 ---
+    @(link_name = "uv_fs_event_start")
+    fs_event_start :: proc(handle: ^fs_event_t, cb: fs_event_cb, path: cstring, flags: u32) -> i32 ---
 
-	@(link_name = "uv_fs_event_start")
-	fs_event_start :: proc(handle: ^uv_fs_event_t, cb: uv_fs_event_cb, path: cstring, flags: u32) -> i32 ---
+    @(link_name = "uv_fs_event_stop")
+    fs_event_stop :: proc(handle: ^fs_event_t) -> i32 ---
 
-	@(link_name = "uv_fs_event_stop")
-	fs_event_stop :: proc(handle: ^uv_fs_event_t) -> i32 ---
+    @(link_name = "uv_fs_event_getpath")
+    fs_event_getpath :: proc(handle: ^fs_event_t, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_fs_event_getpath")
-	fs_event_getpath :: proc(handle: ^uv_fs_event_t, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_ip4_addr")
+    ip4_addr :: proc(ip: cstring, port: i32, addr: ^posix.sockaddr_in) -> i32 ---
 
-	@(link_name = "uv_ip4_addr")
-	ip4_addr :: proc(ip: cstring, port: i32, addr: rawptr) -> i32 ---
+    @(link_name = "uv_ip6_addr")
+    ip6_addr :: proc(ip: cstring, port: i32, addr: ^posix.sockaddr_in6) -> i32 ---
 
-	@(link_name = "uv_ip6_addr")
-	ip6_addr :: proc(ip: cstring, port: i32, addr: rawptr) -> i32 ---
+    @(link_name = "uv_ip4_name")
+    ip4_name :: proc(src: ^posix.sockaddr_in, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_ip4_name")
-	ip4_name :: proc(src: rawptr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_ip6_name")
+    ip6_name :: proc(src: ^posix.sockaddr_in6, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_ip6_name")
-	ip6_name :: proc(src: rawptr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_ip_name")
+    ip_name :: proc(src: ^posix.sockaddr, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_ip_name")
-	ip_name :: proc(src: rawptr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_inet_ntop")
+    inet_ntop :: proc(af: i32, src: rawptr, dst: cstring, size: u64) -> i32 ---
 
-	@(link_name = "uv_inet_ntop")
-	inet_ntop :: proc(af: i32, src: rawptr, dst: cstring, size: u64) -> i32 ---
+    @(link_name = "uv_inet_pton")
+    inet_pton :: proc(af: i32, src: cstring, dst: rawptr) -> i32 ---
 
-	@(link_name = "uv_inet_pton")
-	inet_pton :: proc(af: i32, src: cstring, dst: rawptr) -> i32 ---
+    @(link_name = "uv_random")
+    random :: proc(loop: ^loop_t, req: ^random_t, buf: rawptr, buflen: u64, flags: u32, cb: random_cb) -> i32 ---
 
-	@(link_name = "uv_random")
-	random :: proc(loop: ^uv_loop_t, req: ^uv_random_t, buf: rawptr, buflen: u64, flags: u32, cb: uv_random_cb) -> i32 ---
+    @(link_name = "uv_if_indextoname")
+    if_indextoname :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_if_indextoname")
-	if_indextoname :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_if_indextoiid")
+    if_indextoiid :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_if_indextoiid")
-	if_indextoiid :: proc(ifindex: u32, buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_exepath")
+    exepath :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_exepath")
-	exepath :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_cwd")
+    cwd :: proc(buffer: cstring, size: ^u64) -> i32 ---
 
-	@(link_name = "uv_cwd")
-	cwd :: proc(buffer: cstring, size: ^u64) -> i32 ---
+    @(link_name = "uv_chdir")
+    chdir :: proc(dir: cstring) -> i32 ---
 
-	@(link_name = "uv_chdir")
-	chdir :: proc(dir: cstring) -> i32 ---
+    @(link_name = "uv_get_free_memory")
+    get_free_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_free_memory")
-	get_free_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_total_memory")
+    get_total_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_total_memory")
-	get_total_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_constrained_memory")
+    get_constrained_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_constrained_memory")
-	get_constrained_memory :: proc() -> u64 ---
+    @(link_name = "uv_get_available_memory")
+    get_available_memory :: proc() -> u64 ---
 
-	@(link_name = "uv_get_available_memory")
-	get_available_memory :: proc() -> u64 ---
+    @(link_name = "uv_clock_gettime")
+    clock_gettime :: proc(clock_id_p: clock_id, ts: [^]timespec64_t) -> i32 ---
 
-	@(link_name = "uv_clock_gettime")
-	clock_gettime :: proc(clock_id: uv_clock_id, ts: [^]uv_timespec64_t) -> i32 ---
+    @(link_name = "uv_hrtime")
+    hrtime :: proc() -> u64 ---
 
-	@(link_name = "uv_hrtime")
-	hrtime :: proc() -> u64 ---
+    @(link_name = "uv_sleep")
+    sleep :: proc(msec: u32) ---
 
-	@(link_name = "uv_sleep")
-	sleep :: proc(msec: u32) ---
+    @(link_name = "uv_disable_stdio_inheritance")
+    disable_stdio_inheritance :: proc() ---
 
-	@(link_name = "uv_disable_stdio_inheritance")
-	disable_stdio_inheritance :: proc() ---
+    @(link_name = "uv_dlopen")
+    dlopen :: proc(filename: cstring, lib: ^lib_t) -> i32 ---
 
-	@(link_name = "uv_dlopen")
-	dlopen :: proc(filename: cstring, lib: ^uv_lib_t) -> i32 ---
+    @(link_name = "uv_dlclose")
+    dlclose :: proc(lib: ^lib_t) ---
 
-	@(link_name = "uv_dlclose")
-	dlclose :: proc(lib: ^uv_lib_t) ---
+    @(link_name = "uv_dlsym")
+    dlsym :: proc(lib: ^lib_t, name: cstring, ptr: ^rawptr) -> i32 ---
 
-	@(link_name = "uv_dlsym")
-	dlsym :: proc(lib: ^uv_lib_t, name: cstring, ptr: ^rawptr) -> i32 ---
+    @(link_name = "uv_dlerror")
+    dlerror :: proc(lib: ^lib_t) -> cstring ---
 
-	@(link_name = "uv_dlerror")
-	dlerror :: proc(lib: ^uv_lib_t) -> cstring ---
+    @(link_name = "uv_mutex_init")
+    mutex_init :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_init")
-	mutex_init :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_init_recursive")
+    mutex_init_recursive :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_init_recursive")
-	mutex_init_recursive :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_destroy")
+    mutex_destroy :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_mutex_destroy")
-	mutex_destroy :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_mutex_lock")
+    mutex_lock :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_mutex_lock")
-	mutex_lock :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_mutex_trylock")
+    mutex_trylock :: proc(handle: ^mutex_t) -> i32 ---
 
-	@(link_name = "uv_mutex_trylock")
-	mutex_trylock :: proc(handle: ^uv_mutex_t) -> i32 ---
+    @(link_name = "uv_mutex_unlock")
+    mutex_unlock :: proc(handle: ^mutex_t) ---
 
-	@(link_name = "uv_mutex_unlock")
-	mutex_unlock :: proc(handle: ^uv_mutex_t) ---
+    @(link_name = "uv_rwlock_init")
+    rwlock_init :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_init")
-	rwlock_init :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_destroy")
+    rwlock_destroy :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_destroy")
-	rwlock_destroy :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_rdlock")
+    rwlock_rdlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_rdlock")
-	rwlock_rdlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_tryrdlock")
+    rwlock_tryrdlock :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_tryrdlock")
-	rwlock_tryrdlock :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_rdunlock")
+    rwlock_rdunlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_rdunlock")
-	rwlock_rdunlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_wrlock")
+    rwlock_wrlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_wrlock")
-	rwlock_wrlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_rwlock_trywrlock")
+    rwlock_trywrlock :: proc(rwlock: ^rwlock_t) -> i32 ---
 
-	@(link_name = "uv_rwlock_trywrlock")
-	rwlock_trywrlock :: proc(rwlock: ^uv_rwlock_t) -> i32 ---
+    @(link_name = "uv_rwlock_wrunlock")
+    rwlock_wrunlock :: proc(rwlock: ^rwlock_t) ---
 
-	@(link_name = "uv_rwlock_wrunlock")
-	rwlock_wrunlock :: proc(rwlock: ^uv_rwlock_t) ---
+    @(link_name = "uv_sem_init")
+    sem_init :: proc(sem: ^sem_t, value: u32) -> i32 ---
 
-	@(link_name = "uv_sem_init")
-	sem_init :: proc(sem: ^uv_sem_t, value: u32) -> i32 ---
+    @(link_name = "uv_sem_destroy")
+    sem_destroy :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_destroy")
-	sem_destroy :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_post")
+    sem_post :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_post")
-	sem_post :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_wait")
+    sem_wait :: proc(sem: ^sem_t) ---
 
-	@(link_name = "uv_sem_wait")
-	sem_wait :: proc(sem: ^uv_sem_t) ---
+    @(link_name = "uv_sem_trywait")
+    sem_trywait :: proc(sem: ^sem_t) -> i32 ---
 
-	@(link_name = "uv_sem_trywait")
-	sem_trywait :: proc(sem: ^uv_sem_t) -> i32 ---
+    @(link_name = "uv_cond_init")
+    cond_init :: proc(cond: ^cond_t) -> i32 ---
 
-	@(link_name = "uv_cond_init")
-	cond_init :: proc(cond: ^uv_cond_t) -> i32 ---
+    @(link_name = "uv_cond_destroy")
+    cond_destroy :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_cond_destroy")
-	cond_destroy :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_cond_signal")
+    cond_signal :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_cond_signal")
-	cond_signal :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_cond_broadcast")
+    cond_broadcast :: proc(cond: ^cond_t) ---
 
-	@(link_name = "uv_cond_broadcast")
-	cond_broadcast :: proc(cond: ^uv_cond_t) ---
+    @(link_name = "uv_barrier_init")
+    barrier_init :: proc(barrier: ^barrier_t, count: u32) -> i32 ---
 
-	@(link_name = "uv_barrier_init")
-	barrier_init :: proc(barrier: ^uv_barrier_t, count: u32) -> i32 ---
+    @(link_name = "uv_barrier_destroy")
+    barrier_destroy :: proc(barrier: ^barrier_t) ---
 
-	@(link_name = "uv_barrier_destroy")
-	barrier_destroy :: proc(barrier: ^uv_barrier_t) ---
+    @(link_name = "uv_barrier_wait")
+    barrier_wait :: proc(barrier: ^barrier_t) -> i32 ---
 
-	@(link_name = "uv_barrier_wait")
-	barrier_wait :: proc(barrier: ^uv_barrier_t) -> i32 ---
+    @(link_name = "uv_cond_wait")
+    cond_wait :: proc(cond: ^cond_t, mutex: ^mutex_t) ---
 
-	@(link_name = "uv_cond_wait")
-	cond_wait :: proc(cond: ^uv_cond_t, mutex: ^uv_mutex_t) ---
+    @(link_name = "uv_cond_timedwait")
+    cond_timedwait :: proc(cond: ^cond_t, mutex: ^mutex_t, timeout: u64) -> i32 ---
 
-	@(link_name = "uv_cond_timedwait")
-	cond_timedwait :: proc(cond: ^uv_cond_t, mutex: ^uv_mutex_t, timeout: u64) -> i32 ---
+    @(link_name = "uv_once")
+    once :: proc(guard: rawptr, callback: callback_func_ptr_anon_21) ---
 
-	@(link_name = "uv_once")
-	once :: proc(guard: ^uv_once_t, callback: callback_func_ptr_anon_52) ---
+    @(link_name = "uv_key_create")
+    key_create :: proc(key: ^key_t) -> i32 ---
 
-	@(link_name = "uv_key_create")
-	key_create :: proc(key: ^uv_key_t) -> i32 ---
+    @(link_name = "uv_key_delete")
+    key_delete :: proc(key: ^key_t) ---
 
-	@(link_name = "uv_key_delete")
-	key_delete :: proc(key: ^uv_key_t) ---
+    @(link_name = "uv_key_get")
+    key_get :: proc(key: ^key_t) -> rawptr ---
 
-	@(link_name = "uv_key_get")
-	key_get :: proc(key: ^uv_key_t) -> rawptr ---
+    @(link_name = "uv_key_set")
+    key_set :: proc(key: ^key_t, value: rawptr) ---
 
-	@(link_name = "uv_key_set")
-	key_set :: proc(key: ^uv_key_t, value: rawptr) ---
+    @(link_name = "uv_gettimeofday")
+    gettimeofday :: proc(tv: ^timeval64_t) -> i32 ---
 
-	@(link_name = "uv_gettimeofday")
-	gettimeofday :: proc(tv: ^uv_timeval64_t) -> i32 ---
+    @(link_name = "uv_thread_create")
+    thread_create :: proc(tid: ^thread_t, entry: thread_cb, arg: rawptr) -> i32 ---
 
-	@(link_name = "uv_thread_create")
-	thread_create :: proc(tid: ^uv_thread_t, entry: uv_thread_cb, arg: rawptr) -> i32 ---
+    @(link_name = "uv_thread_create_ex")
+    thread_create_ex :: proc(tid: ^thread_t, params: [^]thread_options_t, entry: thread_cb, arg: rawptr) -> i32 ---
 
-	@(link_name = "uv_thread_create_ex")
-	thread_create_ex :: proc(tid: ^uv_thread_t, params: [^]uv_thread_options_t, entry: uv_thread_cb, arg: rawptr) -> i32 ---
+    @(link_name = "uv_thread_setaffinity")
+    thread_setaffinity :: proc(tid: ^thread_t, cpumask: cstring, oldmask: cstring, mask_size: u64) -> i32 ---
 
-	@(link_name = "uv_thread_setaffinity")
-	thread_setaffinity :: proc(tid: ^uv_thread_t, cpumask: cstring, oldmask: cstring, mask_size: u64) -> i32 ---
+    @(link_name = "uv_thread_getaffinity")
+    thread_getaffinity :: proc(tid: ^thread_t, cpumask: cstring, mask_size: u64) -> i32 ---
 
-	@(link_name = "uv_thread_getaffinity")
-	thread_getaffinity :: proc(tid: ^uv_thread_t, cpumask: cstring, mask_size: u64) -> i32 ---
+    @(link_name = "uv_thread_getcpu")
+    thread_getcpu :: proc() -> i32 ---
 
-	@(link_name = "uv_thread_getcpu")
-	thread_getcpu :: proc() -> i32 ---
+    @(link_name = "uv_thread_self")
+    thread_self :: proc() -> thread_t ---
 
-	@(link_name = "uv_thread_self")
-	thread_self :: proc() -> uv_thread_t ---
+    @(link_name = "uv_thread_join")
+    thread_join :: proc(tid: ^thread_t) -> i32 ---
 
-	@(link_name = "uv_thread_join")
-	thread_join :: proc(tid: ^uv_thread_t) -> i32 ---
+    @(link_name = "uv_thread_equal")
+    thread_equal :: proc(t1: ^thread_t, t2: ^thread_t) -> i32 ---
 
-	@(link_name = "uv_thread_equal")
-	thread_equal :: proc(t1: ^uv_thread_t, t2: ^uv_thread_t) -> i32 ---
+    @(link_name = "uv_loop_get_data")
+    loop_get_data :: proc(param0: ^loop_t) -> rawptr ---
 
-	@(link_name = "uv_loop_get_data")
-	loop_get_data :: proc(param0: ^uv_loop_t) -> rawptr ---
+    @(link_name = "uv_loop_set_data")
+    loop_set_data :: proc(param0: ^loop_t, data: rawptr) ---
 
-	@(link_name = "uv_loop_set_data")
-	loop_set_data :: proc(param0: ^uv_loop_t, data: rawptr) ---
+    @(link_name = "uv_utf16_length_as_wtf8")
+    utf16_length_as_wtf8 :: proc(utf16: ^u16, utf16_len: i64) -> u64 ---
 
-	@(link_name = "uv_utf16_length_as_wtf8")
-	utf16_length_as_wtf8 :: proc(utf16: ^u16, utf16_len: ssize_t) -> u64 ---
+    @(link_name = "uv_utf16_to_wtf8")
+    utf16_to_wtf8 :: proc(utf16: ^u16, utf16_len: i64, wtf8_ptr: ^cstring, wtf8_len_ptr: ^u64) -> i32 ---
 
-	@(link_name = "uv_utf16_to_wtf8")
-	utf16_to_wtf8 :: proc(utf16: ^u16, utf16_len: ssize_t, wtf8_ptr: ^cstring, wtf8_len_ptr: ^u64) -> i32 ---
+    @(link_name = "uv_wtf8_length_as_utf16")
+    wtf8_length_as_utf16 :: proc(wtf8: cstring) -> i64 ---
 
-	@(link_name = "uv_wtf8_length_as_utf16")
-	wtf8_length_as_utf16 :: proc(wtf8: cstring) -> ssize_t ---
-
-	@(link_name = "uv_wtf8_to_utf16")
-	wtf8_to_utf16 :: proc(wtf8: cstring, utf16: ^u16, utf16_len: u64) ---
+    @(link_name = "uv_wtf8_to_utf16")
+    wtf8_to_utf16 :: proc(wtf8: cstring, utf16: ^u16, utf16_len: u64) ---
 
 }
+


### PR DESCRIPTION
Hello, runic developer here! Thank you very much for using runic for your project. I had a look at how you generate your bindings and thought that I could improve them.

To make the bindings generation more host independent I added the header files of libuv to the repo. In the newer runic version it ignores the system include files by default and generates empty stubs of all the different header files from libc. This way libclang shows you errors for all missing types. Then I added stubs for some types of the system includes. These only need to be stubs because of the extern system. Using the extern system you can declare certain headers as extern and then tell runic in which odin package to find them.

Unfortunately not all types can be found in the core odin packages. Some of them were pthread types like `pthread_rwlock_t` and `pthread_once_t`. I added `pthread_rwlock_t` as a 56 byte array to get `uv_loop_t` to work. But ideally you should contribute to the odin core and add those types to the `core:sys/posix` package. This way you can properly reference them in the bindings.

If you have any issues with runic feel free to either contact me or open an issue in the runic repository. And also, since runic is currently heavily under development I suggest you to directly build from the master branch. Unfortunately I don't know which specific Fedora packages you would need to install, but I am sure that you can figure this out.